### PR TITLE
Add Dynamo on g4 (RTX PRO 6000 Blackwell) — Kimi K2.5 NVFP4 + INT4

### DIFF
--- a/dynamo-samples/dynamo-g4/README.md
+++ b/dynamo-samples/dynamo-g4/README.md
@@ -1,0 +1,22 @@
+# Dynamo on GCP g4 (RTX PRO 6000 Blackwell) — Kimi K2.5
+
+NVIDIA Dynamo + SGLang reference deployments for **Kimi K2.5** on Google Cloud's `g4-standard-384` instance (8× RTX PRO 6000 Blackwell, SM_120). 2-node GKE topology, TP=8 + PP=2.
+
+## Quantizations
+
+| Quantization | Directory |
+|---|---|
+| **NVFP4** (recommended for Blackwell) | [`kimi-k25-nvfp4/`](kimi-k25-nvfp4/) |
+| **Native INT4** | [`kimi-k25-int4/`](kimi-k25-int4/) |
+
+Each subdirectory contains its own deployment YAMLs, benchmark scripts, and result tables.
+
+## Why NVFP4 on this hardware
+
+RTX PRO 6000 Blackwell (SM_120) has **native FP4 Tensor Cores**. NVFP4 uses these directly via FlashInfer CUTLASS NVFP4 GEMM + MoE kernels. INT4 on the same hardware runs via Compressed Tensors WNA16 Marlin, which dequantizes INT4 weights to higher precision in registers before the GEMM (no native INT4 Tensor Core path on SM_120). At identical workload, NVFP4 delivers higher throughput than INT4 on this hardware.
+
+## Reference
+
+Google's published Kimi K2.5 references:
+- NVFP4: <https://github.com/shivajid/sglang-rtx-pro-6000/tree/main/models/KimiK2.5/nvfp4>
+- INT4:  <https://github.com/shivajid/sglang-rtx-pro-6000/tree/main/models/KimiK2.5>

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/README.md
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/README.md
@@ -1,0 +1,91 @@
+# Dynamo on GCP g4 (RTX PRO 6000 Blackwell) — Kimi K2.5 Native INT4
+
+NVIDIA Dynamo + SGLang reference deployment for **Kimi K2.5 Native INT4** on Google Cloud's `g4-standard-384` instance (8× RTX PRO 6000 Blackwell, SM_120). 2-node GKE topology, TP=8 + PP=2.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `standalone-sglang-kimi-k25-int4.yaml` | Bare SGLang StatefulSet (2 nodes, TP=8 + PP=2) — matches Google's published Kimi K2.5 INT4 reference flag-for-flag, pinned to SGLang `v0.5.10.post1` (the same version Dynamo's `sglang-runtime:1.1.0` image bundles) for apples-to-apples comparison |
+| `dgd-agg-sglang-kimi-k25-int4.yaml` | Dynamo aggregated DGD (parity) — same engine flags as Standalone, `--router-mode random` (KV routing has no benefit at 1 replica) |
+| `dgd-agg-sglang-kimi-k25-int4-optimized.yaml` | **Template (work in progress)** — Dynamo aggregated DGD with KV-aware routing, radix cache, KV events for shared-prefix workloads. Not yet validated for production; use as a starting point and tune for your workload. |
+| `run-benchmark-natural-eos.sh` | bench_serving / aiperf with **variable OSL** (natural EOS termination) — matches Google's published methodology, direct apples-to-apples comparison |
+| `run-benchmark-parity.sh` | aiperf-based parity benchmark — locked OSL=8192, random workload, deterministic sampling (NVIDIA baseline + Dynamo parity comparison) |
+| `run-benchmark-optimized.sh` | **Template (work in progress)** — sample shared-prefix benchmark (default 80% shared, configurable via `SHARED_PERCENT`) for the optimized Dynamo DGD. Use to explore the latency-vs-throughput trade-off; tune workload to your real distribution. |
+| `benchmark-kimi-k25-int4-pod.yaml` | aiperf client pod (runs the benchmark scripts against either endpoint) |
+
+## Topology
+
+```
+2× g4-standard-384  (16 GPUs total, RTX PRO 6000 Blackwell SM_120)
+├── TP=8 × PP=2     (one distributed SGLang worker across both nodes)
+├── No DP attention (Google's INT4 reference does not enable DP)
+└── Native INT4     (Compressed Tensors WNA16 Marlin MoE, fp8_e5m2 KV cache, mem-fraction 0.85)
+```
+
+## Quick start
+
+```bash
+# Deploy (apply only the variant you want to benchmark — same DGD name swaps with delete+apply)
+kubectl apply -f standalone-sglang-kimi-k25-int4.yaml          # bare SGLang (matches Google ref)
+kubectl apply -f dgd-agg-sglang-kimi-k25-int4.yaml             # Dynamo parity (random router)
+kubectl apply -f dgd-agg-sglang-kimi-k25-int4-optimized.yaml   # Dynamo optimized (KV router + radix)
+kubectl apply -f benchmark-kimi-k25-int4-pod.yaml              # aiperf client pod
+
+# Wait for engine ready (~20-25 min cold start]), then copy scripts once:
+kubectl cp run-benchmark-natural-eos.sh        perf-kimi-k25-int4:/workspace/
+kubectl cp run-benchmark-parity.sh             perf-kimi-k25-int4:/workspace/
+kubectl cp run-benchmark-optimized.sh   perf-kimi-k25-int4:/workspace/
+kubectl exec perf-kimi-k25-int4 -- chmod +x /workspace/run-benchmark-*.sh
+```
+
+Pick the right benchmark for what you want to measure:
+
+```bash
+# Use case 1 — Goal 1 (NVIDIA Standalone vs Google): variable OSL, bench_serving harness.
+# Matches Google's published methodology exactly. Run against the Standalone deployment.
+kubectl exec perf-kimi-k25-int4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-natural-eos.sh standalone > /workspace/bench.log 2>&1 &'
+
+# Use case 2 — Goal 2 (Dynamo Parity vs Standalone): locked OSL=8192, aiperf, random workload.
+# Run twice — once against Standalone, then tear it down and run against Dynamo parity.
+kubectl exec perf-kimi-k25-int4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-parity.sh standalone > /workspace/bench.log 2>&1 &'
+kubectl exec perf-kimi-k25-int4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-parity.sh dynamo > /workspace/bench.log 2>&1 &'
+
+# Use case 3 — Goal 3 (Dynamo optimized): locked OSL, 80% shared prefix (default; override
+# via SHARED_PERCENT=98|50|0). Runs against the Dynamo optimized DGD — exercises radix cache
+# + KV-aware routing.
+kubectl exec perf-kimi-k25-int4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-optimized.sh dynamo > /workspace/bench.log 2>&1 &'
+```
+
+Each YAML and script has inline comments explaining the choices.
+
+## Reference
+
+Google's published Kimi K2.5 INT4 reference: <https://github.com/shivajid/sglang-rtx-pro-6000/tree/main/models/KimiK2.5>
+
+## Performance Benchmarks
+
+Workload: ISL=1024, OSL=8192, conc=512, 1,536 prompts. **bold** = directly comparable column.
+
+| Variant | SGLang version | Benchmark / OSL | Output Throughput (tok/s) | Total Throughput (tok/s) | ITL P50 |
+|---|---|---|---|---|---|
+| Google Standalone (published reference) | `lmsysorg/sglang:v0.5.10.post1` | bench_serving, variable OSL | 3,069 | 3,443 | 134 ms |
+| **NVIDIA Standalone** (matches Google methodology) | `lmsysorg/sglang:v0.5.10.post1` | bench_serving, variable OSL | **3,525** (+14.8%) | **3,955** (+14.8%) | **132 ms** (-1.4%) |
+| **NVIDIA Standalone (aiperf fixed-OSL baseline)** ← Dynamo apples-to-apples reference | `lmsysorg/sglang:v0.5.10.post1` | **aiperf, locked OSL=8192** | **2,377** | **2,677** | **157 ms** |
+| Dynamo parity (vs Standalone aiperf fixed-OSL baseline) | `v0.5.10.post1` (bundled in `sglang-runtime:1.1.0`) | aiperf, locked OSL=8192 | 2,536 (+6.7%) | 2,855 (+6.7%) | 144 ms (-7.9%) |
+| Dynamo optimized — work in progress | `v0.5.10.post1` (bundled in `sglang-runtime:1.1.0`) | aiperf, locked OSL=8192, shared-prefix workload | — | — | — |
+
+*SGLang version note*: NVIDIA Standalone and Dynamo runs are all pinned to `v0.5.10.post1` — the same SGLang version bundled in Dynamo's certified `sglang-runtime:1.1.0` image — so every comparison holds the SGLang code constant and isolates only the Dynamo wrapper effect.
+
+*OSL methodology note*: Google's published reference uses **variable OSL** (natural EOS termination, average ~4,189 output tokens per request). The fixed-OSL baseline (row 3 above) and Dynamo parity (row 4) use **locked OSL=8,192** — every request generates exactly 8,192 output tokens — which exposes Dynamo wrapper overhead clearly but is not directly comparable to Google's variable-OSL number.
+
+*Methodology note for Dynamo parity (row 4)*: Engine flags are identical to the Standalone baseline (row 3), Dynamo Frontend uses `--router-mode random`, and the worker explicitly sets `--disable-radix-cache` so the wrapper effect is isolated from engine cache state. 
+
+**Reading guide:**
+- **Goal 1** (NVIDIA Standalone vs Google): direct apples-to-apples — both use `bench_serving` + variable OSL on the same SGLang version and engine config. NVIDIA Standalone matches and exceeds Google's published numbers on every metric.
+- **Goal 2** (Dynamo parity vs NVIDIA Standalone fixed-OSL baseline): completed. Both runs use `aiperf` + locked OSL + the same SGLang version bundled in Dynamo's certified runtime image, on fresh pods, with radix cache disabled — so the comparison isolates the Dynamo wrapper only. Dynamo parity throughput is +6.7% over the Standalone baseline at locked OSL with random workload, with ITL P50 -7.9% lower.
+- **Goal 3** (Dynamo optimized): work in progress. Dynamo's primary value-add is the KV-aware router + radix cache on shared-prefix workloads, which is the next focus.

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/benchmark-kimi-k25-int4-pod.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/benchmark-kimi-k25-int4-pod.yaml
@@ -1,0 +1,53 @@
+# Benchmark client pod for Kimi K2.5 Native INT4 — 2-node g4 (RTX PRO 6000) GKE cluster.
+# Supports two harnesses via the three benchmark scripts in this directory:
+#   - run-benchmark-natural-eos.sh   bench_serving, variable OSL — Google methodology
+#   - run-benchmark-parity.sh        aiperf, locked OSL=8192, deterministic — Dynamo parity
+#   - run-benchmark-opt-shared.sh    aiperf, 80% shared prefix, locked OSL — optimized template
+# Both aiperf and sglang.bench_serving are pre-installed by the entrypoint.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: perf-kimi-k25-int4
+  labels:
+    app: perf-kimi-k25-int4
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    workload: perf-client    # dedicated n2-standard-8 perf-pool (32 GB / 8 vCPU)
+  containers:
+    - name: perf
+      image: python:3.12-slim
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          apt-get update -qq && apt-get install -y -qq git curl jq procps >/dev/null && apt-get clean
+          # NVIDIA aiperf — for cross-comparison with old g4-dynamo runs.
+          pip install -q "git+https://github.com/ai-dynamo/aiperf.git@main"
+          # SGLang bench_serving — for direct match to Google reference numbers.
+          pip install -q "sglang[runtime_common]==0.5.10.post1"
+          echo "aiperf + sglang.bench_serving installed and ready"
+          exec sleep infinity
+      envFrom:
+        - secretRef:
+            name: hf-token-secret
+      env:
+        - name: TARGET_MODEL
+          value: moonshotai/Kimi-K2.5
+        # Default endpoint is the Dynamo Frontend on this cluster.
+        # Override to kimi-k25-sglang-serving.default.svc.cluster.local:8000 for the standalone baseline.
+        - name: ENDPOINT
+          value: agg-sglang-kimi-k25-int4-frontend.default.svc.cluster.local:8000
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        # Bump HTTP connection ceiling for conc=512 (matches NVFP4 perf pod).
+        - name: AIPERF_HTTP_CONNECTION_LIMIT
+          value: "2000"
+      resources:
+        # Pinned to perf-pool (n2-standard-8: 8 vCPU, 32 GB). Sized for full
+        # workers=64 at conc=512: ~16-20 GB peak memory, 2-4 cores burst.
+        requests: { cpu: "2", memory: "16Gi" }
+        limits:   { cpu: "8", memory: "28Gi" }
+      securityContext:
+        privileged: true
+      workingDir: /workspace

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/dgd-agg-sglang-kimi-k25-int4-optimized.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/dgd-agg-sglang-kimi-k25-int4-optimized.yaml
@@ -1,0 +1,265 @@
+# Dynamo aggregated deployment for Kimi K2.5 Native INT4 — optimized variant
+# (Template: work in progress — not yet validated for production).
+#
+# Same DGD name as the parity baseline → swap with `kubectl delete -f` + `kubectl apply -f`.
+#
+# Changes vs parity:
+#   Frontend: KV events enabled (default; --no-kv-events removed) so the router
+#     gets live worker-side cache state for prefix-aware routing.
+#   Worker engine:
+#     --mem-fraction-static 0.87 (vs 0.85) — more KV pool for radix cache headroom
+#     --enable-tokenizer-batch-encode — reduces tokenizer CPU contention at high conc
+#
+# Apply with a shared-prefix benchmark workload to see the KV-aware routing benefit.
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: agg-sglang-kimi-k25-int4
+  namespace: default
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          command: ["python3"]
+          args:
+            - -m
+            - dynamo.frontend
+            - --router-mode
+            - kv
+            # KV events ENABLED (--no-kv-events removed) — real-time worker-side cache
+            # state lets the router make smarter prefix routing decisions.
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    ModelExpress:
+      componentType: frontend
+      replicas: 1
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { cpu: "4", memory: 16Gi }
+        requests: { cpu: "1", memory: 4Gi }
+      livenessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 120
+        periodSeconds: 30
+        timeoutSeconds: 10
+        failureThreshold: 10
+      readinessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 60
+        periodSeconds: 15
+        timeoutSeconds: 10
+        failureThreshold: 10
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Starting Model Express Server..."
+              ./modelexpress-server &
+              SERVER_PID=$!
+
+              mkdir -p $MODEL_CACHE_PATH /model-cache/.model-express
+              cat > /model-cache/.model-express/config.yaml << EOF
+              local_path: $MODEL_CACHE_PATH
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              for i in $(seq 1 60); do
+                if ./modelexpress-cli --endpoint http://localhost:8000 health > /dev/null 2>&1; then
+                  echo "Server is ready"
+                  break
+                fi
+                sleep 2
+              done
+
+              echo "Downloading $MODEL_NAME ..."
+              ./modelexpress-cli --endpoint http://localhost:8000 \
+                --cache-path $MODEL_CACHE_PATH \
+                model download "$MODEL_NAME"
+
+              SNAPSHOT_DIR=$(ls -td $MODEL_CACHE_PATH/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/*/ 2>/dev/null | head -1)
+              if [ -n "$SNAPSHOT_DIR" ]; then
+                SNAPSHOTS_PARENT=$(dirname "$SNAPSHOT_DIR")
+                ln -sfn "$(basename "$SNAPSHOT_DIR")" "$SNAPSHOTS_PARENT/latest"
+              fi
+
+              wait $SERVER_PID
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: info
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: /model-cache/.model-express/cache
+            - name: MX_METADATA_BACKEND
+              value: redis
+            - name: REDIS_URL
+              value: redis://redis-master.default.svc.cluster.local:6379
+            - name: MODEL_NAME
+              value: moonshotai/Kimi-K2.5
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    agg:
+      componentType: worker
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { gpu: "8" }
+        requests: { gpu: "8" }
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        # hostNetwork on the GPU worker: matches the Google standalone topology so that
+        # NCCL_SOCKET_IFNAME=eth0,eth1 actually uses both gVNICs from the multi-NIC node.
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-spot
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-preemptible
+            operator: Exists
+            effect: NoSchedule
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+          startupProbe:
+            httpGet: { path: /live, port: 9090 }
+            periodSeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 60
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              MODEL_NAME=moonshotai/Kimi-K2.5
+              MODEL_DIR=/model-cache/.model-express/cache/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/latest
+
+              echo "Waiting for model snapshot at $MODEL_DIR ..."
+              for i in $(seq 1 1800); do
+                if [ -f "$MODEL_DIR/config.json" ]; then
+                  echo "Model snapshot ready."
+                  break
+                fi
+                sleep 2
+              done
+              if [ ! -f "$MODEL_DIR/config.json" ]; then
+                echo "ERROR: model snapshot not found at $MODEL_DIR"
+                exit 1
+              fi
+
+              # SGLang launch — optimized config (engine tuning only).
+              exec python3 -m dynamo.sglang \
+                --model-path "$MODEL_DIR" \
+                --served-model-name "$MODEL_NAME" \
+                --trust-remote-code \
+                --tensor-parallel-size 8 \
+                --pipeline-parallel-size 2 \
+                --kv-cache-dtype fp8_e5m2 \
+                --reasoning-parser kimi_k2 \
+                --tool-call-parser kimi_k2 \
+                --mem-fraction-static 0.87 \
+                --chunked-prefill-size 16384 \
+                --enable-tokenizer-batch-encode \
+                --host 0.0.0.0 \
+                --watchdog-timeout 3600
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: MODEL_EXPRESS_URL
+              value: http://agg-sglang-kimi-k25-int4-modelexpress:8000
+            - name: TRITON_CACHE_DIR
+              value: /model-cache/.triton-cache
+            # NCCL — same as Google reference. eth0,eth1 engages both gVNICs.
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0,eth1"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: SYS
+            - name: NCCL_SOCKET_NTHREADS
+              value: "8"
+            - name: NCCL_NSOCKS_PERTHREAD
+              value: "8"
+            - name: NCCL_MIN_NCHANNELS
+              value: "8"
+            - name: NCCL_ALLOC_P2P_NET_LL_BUFFERS
+              value: "1"
+            - name: SGLANG_ENABLE_JIT_DEEPGEMM
+              value: "0"
+            - name: SGLANG_ENABLE_DEEP_GEMM
+              value: "0"
+            - name: SGLANG_DISABLE_DEEP_GEMM
+              value: "1"
+            - name: OMP_NUM_THREADS
+              value: "24"
+            - name: SGLANG_SET_CPU_AFFINITY
+              value: "1"
+            - name: SAFETENSORS_FAST_GPU
+              value: "1"
+            - name: PYTORCH_CUDA_ALLOC_CONF
+              value: "expandable_segments:True"
+            - name: FLASHINFER_DISABLE_VERSION_CHECK
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/dgd-agg-sglang-kimi-k25-int4.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/dgd-agg-sglang-kimi-k25-int4.yaml
@@ -1,0 +1,259 @@
+# Dynamo aggregated deployment for Kimi K2.5 Native INT4 — parity variant.
+#
+# Use this for the Dynamo-vs-Standalone parity comparison. Engine flags are
+# identical to the Standalone SGLang reference manifest; only the routing layer
+# differs (Dynamo Frontend wraps the engine). 2-node TP=8 + PP=2 worker.
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: agg-sglang-kimi-k25-int4
+  namespace: default
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          command: ["python3"]
+          args:
+            - -m
+            - dynamo.frontend
+            - --router-mode
+            - random              # KV routing has no benefit at replicas=1; matches NVFP4 parity
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    ModelExpress:
+      componentType: frontend
+      replicas: 1
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { cpu: "4", memory: 16Gi }
+        requests: { cpu: "1", memory: 4Gi }
+      livenessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 120
+        periodSeconds: 30
+        timeoutSeconds: 10
+        failureThreshold: 10
+      readinessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 60
+        periodSeconds: 15
+        timeoutSeconds: 10
+        failureThreshold: 10
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Starting Model Express Server..."
+              ./modelexpress-server &
+              SERVER_PID=$!
+
+              mkdir -p $MODEL_CACHE_PATH /model-cache/.model-express
+              cat > /model-cache/.model-express/config.yaml << EOF
+              local_path: $MODEL_CACHE_PATH
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              for i in $(seq 1 60); do
+                if ./modelexpress-cli --endpoint http://localhost:8000 health > /dev/null 2>&1; then
+                  echo "Server is ready"
+                  break
+                fi
+                sleep 2
+              done
+
+              echo "Downloading $MODEL_NAME ..."
+              # Default strategy (NOT --strategy server-only) so tokenizer/processor/
+              # index files land in the snapshot directory.
+              ./modelexpress-cli --endpoint http://localhost:8000 \
+                --cache-path $MODEL_CACHE_PATH \
+                model download "$MODEL_NAME"
+
+              SNAPSHOT_DIR=$(ls -td $MODEL_CACHE_PATH/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/*/ 2>/dev/null | head -1)
+              if [ -n "$SNAPSHOT_DIR" ]; then
+                SNAPSHOTS_PARENT=$(dirname "$SNAPSHOT_DIR")
+                ln -sfn "$(basename "$SNAPSHOT_DIR")" "$SNAPSHOTS_PARENT/latest"
+              fi
+
+              wait $SERVER_PID
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: info
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: /model-cache/.model-express/cache
+            - name: MX_METADATA_BACKEND
+              value: redis
+            - name: REDIS_URL
+              value: redis://redis-master.default.svc.cluster.local:6379
+            - name: MODEL_NAME
+              value: moonshotai/Kimi-K2.5
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    agg:
+      componentType: worker
+      replicas: 1
+      multinode:
+        nodeCount: 2
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { gpu: "8" }
+        requests: { gpu: "8" }
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        # hostNetwork on the GPU worker so NCCL_SOCKET_IFNAME=eth0,eth1 engages both
+        # gVNICs from the multi-NIC node (matches Google's standalone topology).
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-spot
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-preemptible
+            operator: Exists
+            effect: NoSchedule
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+          startupProbe:
+            httpGet: { path: /live, port: 9090 }
+            periodSeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 60
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              MODEL_NAME=moonshotai/Kimi-K2.5
+              MODEL_DIR=/model-cache/.model-express/cache/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/latest
+
+              echo "Waiting for model snapshot at $MODEL_DIR ..."
+              for i in $(seq 1 1800); do
+                if [ -f "$MODEL_DIR/config.json" ]; then
+                  echo "Model snapshot ready."
+                  break
+                fi
+                sleep 2
+              done
+              if [ ! -f "$MODEL_DIR/config.json" ]; then
+                echo "ERROR: model snapshot not found at $MODEL_DIR"
+                exit 1
+              fi
+
+              # SGLang launch — same flags as standalone Google reference.
+              # --nnodes / --node-rank / --dist-init-addr injected by Dynamo's multinode.
+              exec python3 -m dynamo.sglang \
+                --model-path "$MODEL_DIR" \
+                --served-model-name "$MODEL_NAME" \
+                --trust-remote-code \
+                --tensor-parallel-size 8 \
+                --pipeline-parallel-size 2 \
+                --kv-cache-dtype fp8_e5m2 \
+                --reasoning-parser kimi_k2 \
+                --tool-call-parser kimi_k2 \
+                --mem-fraction-static 0.85 \
+                --chunked-prefill-size 16384 \
+                --disable-radix-cache \
+                --host 0.0.0.0 \
+                --watchdog-timeout 3600
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: MODEL_EXPRESS_URL
+              value: http://agg-sglang-kimi-k25-int4-modelexpress:8000
+            # Filestore-backed Triton cache — shared across pods, survives restart.
+            - name: TRITON_CACHE_DIR
+              value: /model-cache/.triton-cache
+            # NCCL — same as Google reference. eth0,eth1 engages both gVNICs.
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0,eth1"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: SYS
+            - name: NCCL_SOCKET_NTHREADS
+              value: "8"
+            - name: NCCL_NSOCKS_PERTHREAD
+              value: "8"
+            - name: NCCL_MIN_NCHANNELS
+              value: "8"
+            - name: NCCL_ALLOC_P2P_NET_LL_BUFFERS
+              value: "1"
+            - name: SGLANG_ENABLE_JIT_DEEPGEMM
+              value: "0"
+            - name: SGLANG_ENABLE_DEEP_GEMM
+              value: "0"
+            - name: SGLANG_DISABLE_DEEP_GEMM
+              value: "1"
+            - name: OMP_NUM_THREADS
+              value: "24"
+            - name: SGLANG_SET_CPU_AFFINITY
+              value: "1"
+            - name: SAFETENSORS_FAST_GPU
+              value: "1"
+            - name: PYTORCH_CUDA_ALLOC_CONF
+              value: "expandable_segments:True"
+            - name: FLASHINFER_DISABLE_VERSION_CHECK
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/run-benchmark-natural-eos.sh
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/run-benchmark-natural-eos.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Natural-EOS benchmark for Kimi K2.5 INT4 — matches Google reference methodology
+# (variable OSL via natural EOS termination). Use for the direct Google comparison.
+#
+# Difference vs run-benchmark-parity.sh (locked OSL=8192):
+#   - aiperf:        drops --extra-inputs ignore_eos:true
+#   - bench_serving: adds --disable-ignore-eos
+#
+# Default harness per target (override with HARNESS=...):
+#   standalone -> bench_serving (matches Google reference command exactly)
+#   dynamo     -> aiperf        (Dynamo customer-facing harness)
+#
+# Usage:
+#   ./run-benchmark-natural-eos.sh standalone                  # Google-methodology standalone
+#   ./run-benchmark-natural-eos.sh dynamo                      # Dynamo at Google methodology
+#   HARNESS=bench ./run-benchmark-natural-eos.sh dynamo        # bench cross-check on Dynamo
+#   ./run-benchmark-natural-eos.sh <full-url>
+
+set -euo pipefail
+
+TARGET=${1:-dynamo}
+case "$TARGET" in
+  standalone) DEFAULT_HARNESS=bench ;;
+  *)          DEFAULT_HARNESS=aiperf ;;
+esac
+HARNESS=${HARNESS:-$DEFAULT_HARNESS}
+
+case "$TARGET" in
+  dynamo)
+    URL="http://agg-sglang-kimi-k25-int4-frontend.default.svc.cluster.local:8000"
+    TAG="dynamo"
+    ;;
+  standalone)
+    URL="http://kimi-k25-sglang-serving.default.svc.cluster.local:8000"
+    TAG="standalone"
+    ;;
+  http*)
+    URL="$TARGET"
+    TAG="custom"
+    ;;
+  *)
+    echo "Usage: $0 [dynamo|standalone|<url>]   (env: HARNESS=aiperf|bench)" >&2
+    exit 1
+    ;;
+esac
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/workspace/results/kimi-k25-int4-c512-1536req-${TAG}-natEOS-${HARNESS}}
+mkdir -p "$ARTIFACT_DIR"
+
+echo "==> Natural-EOS methodology (variable OSL, matches Google reference)"
+echo "==> Target=${TARGET} (${URL}); Harness=${HARNESS}"
+echo "==> Artifacts: ${ARTIFACT_DIR}"
+
+if [[ "$HARNESS" == "aiperf" ]]; then
+  # Random workload, ISL=1024, max OSL=8192 but no ignore_eos -> Kimi EOS terminates
+  # at ~4,189 avg OSL (same as Google's reference run).
+  aiperf profile \
+    --model moonshotai/Kimi-K2.5 \
+    --url "$URL" \
+    --endpoint-type chat \
+    --streaming \
+    --tokenizer moonshotai/Kimi-K2.5 \
+    --tokenizer-trust-remote-code \
+    --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 \
+    --output-tokens-mean 8192 --output-tokens-stddev 0 \
+    --num-prompts 1536 --num-requests 1536 \
+    --concurrency 512 \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --ui simple
+else
+  HOST_PORT=${URL#http://}
+  HOST_PORT=${HOST_PORT#https://}
+  HOST=${HOST_PORT%:*}
+  PORT=${HOST_PORT##*:}
+
+  # bench_serving's default in this sglang version is ignore_eos=true; explicitly
+  # disable it to match Google's natural-EOS methodology.
+  python3 -m sglang.bench_serving \
+    --backend sglang-oai \
+    --host "$HOST" --port "$PORT" \
+    --model moonshotai/Kimi-K2.5 \
+    --tokenizer moonshotai/Kimi-K2.5 \
+    --dataset-name random \
+    --random-input-len 1024 --random-output-len 8192 \
+    --num-prompts 1536 \
+    --max-concurrency 512 \
+    --apply-chat-template \
+    --disable-ignore-eos \
+    --output-file "$ARTIFACT_DIR/bench_serving.json"
+fi
+
+echo "Results in: $ARTIFACT_DIR"

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/run-benchmark-optimized.sh
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/run-benchmark-optimized.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Template (work in progress) — shared-prefix benchmark for Kimi K2.5 INT4 with
+# configurable shared-prefix percentage. Pairs with the optimized Dynamo DGD
+# (KV-aware router + radix cache).
+#
+# Default harness per target (override with HARNESS=...):
+#   dynamo     -> aiperf         (radix-cache warmup methodology)
+#   standalone -> bench_serving
+#
+# Shared-prefix percentage knob (env: SHARED_PERCENT, default 80):
+#   - 98 (max shared) : 1024 prefix + 16 unique. ISL=1040.
+#   - 80 (default)    : 820 prefix + 204 unique. ISL=1024.
+#   - 50              : 512 prefix + 512 unique. ISL=1024.
+#   - 0  (near-random): 1 + 1023.
+#   - any other value: prefix = ISL*pct/100, unique = ISL - prefix.
+#
+# Usage:
+#   ./run-benchmark-opt-shared.sh dynamo                         # 80% shared (default)
+#   SHARED_PERCENT=98 ./run-benchmark-opt-shared.sh dynamo       # 98% shared
+#   SHARED_PERCENT=80 HARNESS=bench ./run-benchmark-opt-shared.sh dynamo
+#   ./run-benchmark-opt-shared.sh <full-url>                     # custom endpoint
+
+set -euo pipefail
+
+TARGET=${1:-dynamo}
+case "$TARGET" in
+  standalone) DEFAULT_HARNESS=bench ;;
+  *)          DEFAULT_HARNESS=aiperf ;;
+esac
+HARNESS=${HARNESS:-$DEFAULT_HARNESS}
+
+case "$TARGET" in
+  dynamo)
+    URL="http://agg-sglang-kimi-k25-int4-frontend.default.svc.cluster.local:8000"
+    TAG="dynamo"
+    ;;
+  standalone)
+    URL="http://kimi-k25-sglang-serving.default.svc.cluster.local:8000"
+    TAG="standalone"
+    ;;
+  http*)
+    URL="$TARGET"
+    TAG="custom"
+    ;;
+  *)
+    echo "Usage: $0 [dynamo|standalone|<url>]   (env: HARNESS=aiperf|bench  SHARED_PERCENT=80|98|50|0)" >&2
+    exit 1
+    ;;
+esac
+
+# Shared-prefix workload composition — total ISL ~1024 tokens, split prefix vs unique tail.
+SHARED_PERCENT=${SHARED_PERCENT:-80}
+TARGET_ISL=1024
+
+case "$SHARED_PERCENT" in
+  98) PREFIX_LEN=1024; SYNTHETIC=16 ;;     # max shared (ISL=1040)
+  80) PREFIX_LEN=820;  SYNTHETIC=204 ;;
+  50) PREFIX_LEN=512;  SYNTHETIC=512 ;;
+  0)  PREFIX_LEN=1;    SYNTHETIC=1023 ;;   # near-random (aiperf requires prefix > 0)
+  *)
+    PREFIX_LEN=$(( TARGET_ISL * SHARED_PERCENT / 100 ))
+    SYNTHETIC=$(( TARGET_ISL - PREFIX_LEN ))
+    ;;
+esac
+
+POOL_SIZE=64
+WARMUP_COUNT=$(( POOL_SIZE * 2 ))   # 2x pool so every prefix is warmed into radix cache
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/workspace/results/kimi-k25-int4-c512-1536req-${TAG}-opt-${HARNESS}-shared${SHARED_PERCENT}}
+mkdir -p "$ARTIFACT_DIR"
+
+echo "==> Shared prefix=${SHARED_PERCENT}% (prefix=${PREFIX_LEN}, unique=${SYNTHETIC}); pool=${POOL_SIZE}; warmup=${WARMUP_COUNT}"
+echo "==> Target=${TARGET} (${URL}); Harness=${HARNESS}"
+echo "==> Artifacts: ${ARTIFACT_DIR}"
+
+if [[ "$HARNESS" == "aiperf" ]]; then
+  aiperf profile \
+    --model moonshotai/Kimi-K2.5 \
+    --url "$URL" \
+    --endpoint-type chat \
+    --streaming \
+    --tokenizer moonshotai/Kimi-K2.5 \
+    --tokenizer-trust-remote-code \
+    --prefix-prompt-length "$PREFIX_LEN" \
+    --prefix-prompt-pool-size "$POOL_SIZE" \
+    --synthetic-input-tokens-mean "$SYNTHETIC" --synthetic-input-tokens-stddev 0 \
+    --output-tokens-mean 8192 --output-tokens-stddev 0 \
+    --num-prompts 1536 --num-requests 1536 \
+    --warmup-request-count "$WARMUP_COUNT" \
+    --use-server-token-count \
+    --concurrency 512 \
+    --record-processors 16 \
+    --random-seed 100 \
+    --extra-inputs ignore_eos:true \
+    --extra-inputs max_tokens:8192 \
+    --extra-inputs min_tokens:8192 \
+    --extra-inputs temperature:0.0 \
+    --extra-inputs repetition_penalty:1.0 \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --ui simple
+else
+  HOST_PORT=${URL#http://}
+  HOST_PORT=${HOST_PORT#https://}
+  HOST=${HOST_PORT%:*}
+  PORT=${HOST_PORT##*:}
+
+  PROMPTS_PER_GROUP=$(( 1536 / POOL_SIZE ))   # 24 for pool=64
+  python3 -m sglang.bench_serving \
+    --backend sglang-oai \
+    --host "$HOST" --port "$PORT" \
+    --model moonshotai/Kimi-K2.5 \
+    --tokenizer moonshotai/Kimi-K2.5 \
+    --dataset-name generated-shared-prefix \
+    --gsp-num-groups "$POOL_SIZE" \
+    --gsp-prompts-per-group "$PROMPTS_PER_GROUP" \
+    --gsp-system-prompt-len "$PREFIX_LEN" \
+    --gsp-question-len "$SYNTHETIC" \
+    --gsp-output-len 8192 \
+    --max-concurrency 512 \
+    --warmup-requests "$WARMUP_COUNT" \
+    --apply-chat-template \
+    --seed 100 \
+    --extra-request-body '{"ignore_eos":true,"min_tokens":8192,"max_tokens":8192,"temperature":0.0,"repetition_penalty":1.0}' \
+    --output-file "$ARTIFACT_DIR/bench_serving.json"
+fi
+
+echo "Results in: $ARTIFACT_DIR"

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/run-benchmark-parity.sh
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/run-benchmark-parity.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Clean Dynamo-vs-Standalone parity test (apples-to-apples for Goal 2).
+#
+# WHY THIS SCRIPT EXISTS:
+# To answer "is Dynamo on par with Standalone SGLang at single-instance?" without
+# methodology noise, we run the SAME aiperf command against both endpoints with:
+#   - aiperf on both sides       (no harness instrumentation drift)
+#   - LOCKED OSL=8192 (ignore_eos=true + min/max_tokens=8192)
+#                                (eliminates EOS-distribution variance; engine
+#                                 runs in steady-state decode where Dynamo
+#                                 overhead is most visible)
+#   - random workload            (no shared prefix -- KV routing has no effect)
+#   - deterministic sampling     (temperature=0, rep_penalty=1.0, random-seed=100)
+#   - same engine config         (Standalone manifest = Dynamo DGD engine flags)
+# Any leftover delta is Dynamo's Frontend / service-mesh / router overhead.
+#
+# NOTE on methodology choice (locked vs variable OSL):
+#   For Goal 2 (Dynamo-vs-Standalone parity on OUR cluster), LOCKED OSL is the
+#   cleaner test -- removes EOS variance, makes overhead visible.
+#   For Goal 1 (Standalone vs Google reference), use VARIABLE OSL via
+#   `run-benchmark-natural-eos.sh standalone` -- matches Google's methodology.
+#
+# PREREQUISITES:
+#   1. Dynamo parity DGD applied (random router):
+#      kubectl apply -f dgd-agg-sglang-kimi-k25-int4-parity.yaml
+#      (Uses --router-mode random; KV routing has no benefit at replicas=1.)
+#   2. Standalone INT4 deployment ALSO running for the standalone leg:
+#      kubectl apply -f standalone-sglang-kimi-k25-int4.yaml
+#      (They share the model-cache PVC; OK to have both deployed simultaneously.)
+#   3. Perf pod running:
+#      kubectl apply -f benchmark-kimi-k25-int4-pod.yaml
+#
+# USAGE:
+#   ./run-benchmark-parity.sh standalone                 # aiperf vs Standalone (default)
+#   ./run-benchmark-parity.sh dynamo                     # aiperf vs Dynamo (default)
+#   HARNESS=bench  ./run-benchmark-parity.sh dynamo      # bench_serving cross-check vs Dynamo
+#   HARNESS=bench  ./run-benchmark-parity.sh standalone  # bench_serving cross-check vs Standalone
+#   HARNESS=aiperf ./run-benchmark-parity.sh dynamo      # explicit aiperf (same as default)
+#   ./run-benchmark-parity.sh <full-url>                 # custom endpoint
+#
+# Run both targets sequentially (don't overlap on the same cluster).
+#
+# Note: this locked-OSL aiperf run isolates Dynamo-wrapper overhead vs Standalone
+# at identical workload — it is NOT methodology-matched to Google's published number.
+# For the Google-comparable run see run-benchmark-natural-eos.sh standalone.
+
+set -euo pipefail
+
+TARGET=${1:-dynamo}
+HARNESS=${HARNESS:-aiperf}      # default aiperf; override with HARNESS=bench for sglang.bench_serving
+
+case "$TARGET" in
+  dynamo)
+    URL="http://agg-sglang-kimi-k25-int4-frontend.default.svc.cluster.local:8000"
+    TAG="dynamo"
+    ;;
+  standalone)
+    URL="http://kimi-k25-sglang-serving.default.svc.cluster.local:8000"
+    TAG="standalone"
+    ;;
+  http*)
+    URL="$TARGET"
+    TAG="custom"
+    ;;
+  *)
+    echo "Usage: $0 [dynamo|standalone|<url>]   (env: HARNESS=aiperf|bench)" >&2
+    exit 1
+    ;;
+esac
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/workspace/results/kimi-k25-int4-c512-1536req-${TAG}-parity-${HARNESS}}
+mkdir -p "$ARTIFACT_DIR"
+
+echo "==> Parity test (${HARNESS}, LOCKED OSL=8192, random workload, deterministic sampling)"
+echo "==> Target=${TARGET} (${URL})"
+echo "==> Artifacts: ${ARTIFACT_DIR}"
+
+# aiperf with:
+#   - ISL=1024 (locked synthetic input length)
+#   - OSL=8192 LOCKED via ignore_eos + min_tokens=max_tokens=8192
+#       (every request generates exactly 8192 tokens -- removes EOS variance,
+#        engine runs in steady-state decode, Dynamo overhead most visible)
+#   - random prompts (no --prefix-prompt-* flags) -> no shared prefix
+#   - conc=512, 1536 requests -> matches Google reference workload sizing
+#   - Deterministic sampling (temperature=0, rep_penalty=1.0) + random-seed=100
+#     -> reproducible across runs
+if [[ "$HARNESS" == "aiperf" ]]; then
+  aiperf profile \
+    --model moonshotai/Kimi-K2.5 \
+    --url "$URL" \
+    --endpoint-type chat \
+    --streaming \
+    --tokenizer moonshotai/Kimi-K2.5 \
+    --tokenizer-trust-remote-code \
+    --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 \
+    --output-tokens-mean 8192 --output-tokens-stddev 0 \
+    --num-prompts 1536 --num-requests 1536 \
+    --use-server-token-count \
+    --concurrency 512 \
+    --record-processors 16 \
+    --random-seed 100 \
+    --extra-inputs ignore_eos:true \
+    --extra-inputs max_tokens:8192 \
+    --extra-inputs min_tokens:8192 \
+    --extra-inputs temperature:0.0 \
+    --extra-inputs repetition_penalty:1.0 \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --ui simple
+else
+  # bench_serving cross-check path -- random workload, locked OSL=8192, deterministic sampling.
+  # Mirrors the aiperf path's methodology for harness cross-validation.
+  HOST_PORT=${URL#http://}
+  HOST_PORT=${HOST_PORT#https://}
+  HOST=${HOST_PORT%:*}
+  PORT=${HOST_PORT##*:}
+
+  python3 -m sglang.bench_serving \
+    --backend sglang-oai \
+    --host "$HOST" --port "$PORT" \
+    --model moonshotai/Kimi-K2.5 \
+    --tokenizer moonshotai/Kimi-K2.5 \
+    --dataset-name random \
+    --random-input-len 1024 --random-output-len 8192 \
+    --num-prompts 1536 \
+    --max-concurrency 512 \
+    --apply-chat-template \
+    --seed 100 \
+    --extra-request-body '{"ignore_eos":true,"min_tokens":8192,"max_tokens":8192,"temperature":0.0,"repetition_penalty":1.0}' \
+    --output-file "$ARTIFACT_DIR/bench_serving.json"
+fi
+
+echo "Results in: $ARTIFACT_DIR"

--- a/dynamo-samples/dynamo-g4/kimi-k25-int4/standalone-sglang-kimi-k25-int4.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-int4/standalone-sglang-kimi-k25-int4.yaml
@@ -1,0 +1,139 @@
+# Raw SGLang baseline for Kimi K2.5 Native INT4 — 2-node g4 (RTX PRO 6000) GKE cluster.
+# Mirrors https://github.com/shivajid/sglang-rtx-pro-6000/blob/main/models/KimiK2.5/sglang-ss.yaml
+# flag-for-flag. Topology: TP=8 + PP=2 across 2 g4-standard-384 nodes as one distributed
+# SGLang worker (StatefulSet replicas=2 = the two pods of that worker).
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kimi-k25-sglang
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kimi-k25-sglang
+  serviceName: ""
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-sglang
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        # GPU pool on us-south1 is --spot (only approved quota path). Tolerate.
+        - key: cloud.google.com/gke-spot
+          operator: Exists
+          effect: NoSchedule
+        - key: cloud.google.com/gke-preemptible
+          operator: Exists
+          effect: NoSchedule
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: sglang
+          image: docker.io/lmsysorg/sglang:v0.5.10.post1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              python3 -m sglang.launch_server \
+                --model moonshotai/Kimi-K2.5 \
+                --tensor-parallel-size 8 \
+                --pipeline-parallel-size 2 \
+                --nnodes 2 \
+                --node-rank $POD_INDEX \
+                --port 8000 \
+                --dist-init-addr kimi-k25-sglang-master:5000 \
+                --trust-remote-code \
+                --kv-cache-dtype fp8_e5m2 \
+                --reasoning-parser kimi_k2 \
+                --tool-call-parser kimi_k2 \
+                --mem-fraction-static 0.85 \
+                --chunked-prefill-size 16384 \
+                --host 0.0.0.0
+          env:
+            - name: POD_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            # HF_TOKEN required: hf-cache is emptyDir, so each pod re-downloads the
+            # model on cold start. Kimi K2.5 is a gated repo.
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0,eth1"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: SYS
+            - name: NCCL_SOCKET_NTHREADS
+              value: "8"
+            - name: NCCL_NSOCKS_PERTHREAD
+              value: "8"
+            - name: NCCL_MIN_NCHANNELS
+              value: "8"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /root/.cache/huggingface
+              name: hf-cache
+          securityContext:
+            privileged: true
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        # hf-cache on the pod's ephemeral storage — automatically backed by local NVMe
+        # because the GPU pool was created with --ephemeral-storage-local-ssd=count=32.
+        # Matches Google reference. Trade-off: each pod re-downloads on cold start
+        # (~700 GB; 10–15 min on the multi-NIC 200 Gbps gVNIC).
+        - name: hf-cache
+          emptyDir: {}
+---
+# Pod-0 only: distributed init address (--dist-init-addr).
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25-sglang-master
+spec:
+  type: ClusterIP
+  selector:
+    app: kimi-k25-sglang
+    apps.kubernetes.io/pod-index: "0"
+  ports:
+    - name: dist
+      port: 5000
+      targetPort: 5000
+---
+# Pod-0 only: the inference endpoint. Pod-1 is the second leg of the distributed worker.
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25-sglang-serving
+spec:
+  type: ClusterIP
+  selector:
+    app: kimi-k25-sglang
+    apps.kubernetes.io/pod-index: "0"
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+    - name: metrics
+      port: 8080
+      targetPort: 8080

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/README.md
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/README.md
@@ -1,0 +1,87 @@
+# Dynamo on GCP g4 (RTX PRO 6000 Blackwell) — Kimi K2.5 NVFP4
+
+NVIDIA Dynamo + SGLang reference deployment for **Kimi K2.5 NVFP4** on Google Cloud's `g4-standard-384` instance (8× RTX PRO 6000 Blackwell, SM_120). 2-node GKE topology, TP=8 + PP=2.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `standalone-sglang-kimi-k25-nvfp4.yaml` | Bare SGLang StatefulSet (2 nodes, TP=8 + PP=2) — matches Google's published Kimi NVFP4 reference flag-for-flag, but pins SGLang to `v0.5.10.post1` (the version Dynamo's `sglang-runtime:1.1.0` image bundles) for apples-to-apples comparison |
+| `dgd-agg-sglang-kimi-k25-nvfp4-parity.yaml` | Dynamo aggregated DGD — same engine flags as Standalone, `--router-mode random` (KV routing has no benefit at 1 replica) |
+| `dgd-agg-sglang-kimi-k25-nvfp4-optimized.yaml` | **Template (work in progress)** — Dynamo aggregated DGD with KV-aware routing, radix cache, KV events for shared-prefix workloads. Not yet validated for production; use as a starting point and tune for your workload. |
+| `run-benchmark-natural-eos.sh` | bench_serving / aiperf with **variable OSL** (natural EOS termination) — matches Google's published methodology, direct apples-to-apples comparison |
+| `run-benchmark-parity.sh` | aiperf-based parity benchmark — same workload to both Standalone and Dynamo endpoints, locked OSL=8192, deterministic sampling |
+| `run-benchmark-optimized.sh` | **Template (work in progress)** — sample shared-prefix benchmark (default 80% shared, configurable via `SHARED_PERCENT`) for the optimized Dynamo DGD. Use to explore the latency-vs-throughput trade-off; tune workload to your real distribution. |
+| `benchmark-kimi-k25-nvfp4-pod.yaml` | aiperf client pod (runs the benchmark scripts against either endpoint) |
+
+## Topology
+
+```
+2× g4-standard-384  (16 GPUs total, RTX PRO 6000 Blackwell SM_120)
+├── TP=8 × PP=2     (one distributed SGLang worker across both nodes)
+├── DP=8            (DP attention on for MoE)
+└── modelopt_fp4    (NVFP4 weights ~370 GB, bf16 KV cache, mem-fraction 0.82)
+```
+
+## Quick start
+
+```bash
+# Deploy (apply only the variant you want to benchmark — same DGD name swaps with delete+apply)
+kubectl apply -f standalone-sglang-kimi-k25-nvfp4.yaml         # bare SGLang (matches Google ref)
+kubectl apply -f dgd-agg-sglang-kimi-k25-nvfp4-parity.yaml     # Dynamo parity (random router)
+kubectl apply -f dgd-agg-sglang-kimi-k25-nvfp4-optimized.yaml  # Dynamo optimized (KV router + radix)
+kubectl apply -f benchmark-kimi-k25-nvfp4-pod.yaml             # aiperf client pod
+
+# Wait for engine ready (~12-15 min), then copy scripts to the client pod once:
+kubectl cp run-benchmark-natural-eos.sh        perf-kimi-k25-nvfp4:/workspace/
+kubectl cp run-benchmark-parity.sh             perf-kimi-k25-nvfp4:/workspace/
+kubectl cp run-benchmark-optimized.sh   perf-kimi-k25-nvfp4:/workspace/
+kubectl exec perf-kimi-k25-nvfp4 -- chmod +x /workspace/run-benchmark-*.sh
+```
+
+Pick the right benchmark for what you want to measure:
+
+```bash
+# Use case 1 — Goal 1 (NVIDIA Standalone vs Google): variable OSL, bench_serving harness.
+# Matches Google's published methodology exactly. Run against the Standalone deployment.
+kubectl exec perf-kimi-k25-nvfp4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-natural-eos.sh standalone > /workspace/bench.log 2>&1 &'
+
+# Use case 2 — Goal 2 (Dynamo Parity vs Standalone): locked OSL=8192, aiperf, random workload.
+# Run twice — once against Standalone, then tear it down and run against Dynamo parity.
+kubectl exec perf-kimi-k25-nvfp4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-parity.sh standalone > /workspace/bench.log 2>&1 &'
+kubectl exec perf-kimi-k25-nvfp4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-parity.sh dynamo > /workspace/bench.log 2>&1 &'
+
+# Use case 3 — Goal 3 (Dynamo optimized): locked OSL, 80% shared prefix (default; override
+# via SHARED_PERCENT=98|50|0). Runs against the Dynamo optimized DGD — exercises radix cache
+# + KV-aware routing.
+kubectl exec perf-kimi-k25-nvfp4 -- bash -c \
+  'nohup setsid /workspace/run-benchmark-optimized.sh dynamo > /workspace/bench.log 2>&1 &'
+```
+
+Each YAML and script has inline comments explaining the choices.
+
+## Reference
+
+Google's published Kimi K2.5 NVFP4 reference: <https://github.com/shivajid/sglang-rtx-pro-6000/tree/main/models/KimiK2.5/nvfp4>
+
+## Performance Benchmarks
+
+Workload: ISL=1024, OSL=8192, conc=512, 1,536 prompts. **bold** = directly comparable column.
+
+| Variant | SGLang version | Benchmark / OSL | Output Throughput (tok/s) | Total Throughput (tok/s) | ITL P50 |
+|---|---|---|---|---|---|
+| Google Standalone (published reference) | `lmsysorg/sglang:dev-cu13` | bench_serving, variable OSL | 3,237 | 3,632 | 121 ms |
+| **NVIDIA Standalone** (matches Google methodology) | `lmsysorg/sglang:dev-cu13` | bench_serving, variable OSL | **3,374** (+4.2%) | **~3,786** (+4.2%) | **118 ms** (-2.5%) |
+| **NVIDIA Standalone (aiperf fixed-OSL baseline)** ← Dynamo apples-to-apples reference | `lmsysorg/sglang:v0.5.10.post1` | **aiperf, locked OSL=8192** | **3,971** | **4,480** | **122.6 ms** |
+| Dynamo parity (vs Standalone aiperf fixed-OSL baseline) | `v0.5.10.post1` (bundled in `sglang-runtime:1.1.0`) | aiperf, locked OSL=8192 | 3,723 (-6.2%) | 4,200 (-6.2%) | 128.0 ms (+4.4%) |
+| Dynamo optimized — work in progress | `v0.5.10.post1` (bundled in `sglang-runtime:1.1.0`) | aiperf, locked OSL=8192, shared-prefix workload | — | — | — |
+
+*SGLang version note*: The Standalone fixed-OSL baseline (row 3) is intentionally pinned to `v0.5.10.post1` — the same SGLang version bundled in Dynamo's certified `sglang-runtime:1.1.0` image — so the Dynamo parity comparison (row 4) holds the SGLang code constant and isolates the wrapper effect from upstream SGLang version drift. Rows 1-2 use the rolling `dev-cu13` tag to match Google's published methodology.
+
+**Reading guide:**
+- **Goal 1** (NVIDIA Standalone vs Google): direct apples-to-apples — both use `bench_serving` + variable OSL. NVIDIA Standalone matches and slightly exceeds Google's reference on every metric.
+- **Goal 2** (Dynamo parity vs NVIDIA Standalone fixed-OSL baseline): completed. Both runs use `aiperf` + locked OSL + the same SGLang version that's bundled in Dynamo's certified runtime image, so the comparison isolates the Dynamo wrapper from engine config differences. Throughput within ~6% of the baseline.
+- **Goal 3** (Dynamo optimized): work in progress. Dynamo's primary value-add is the KV-aware router + radix cache on shared-prefix workloads, which is the next focus.

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/benchmark-kimi-k25-nvfp4-pod.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/benchmark-kimi-k25-nvfp4-pod.yaml
@@ -1,0 +1,40 @@
+# Benchmark client pod for Kimi K2.5 NVFP4.
+# Installs both aiperf and sglang.bench_serving; harness selected by run-benchmark.sh.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: perf-kimi-k25-nvfp4
+  labels:
+    app: perf-kimi-k25-nvfp4
+spec:
+  restartPolicy: Never
+  containers:
+    - name: perf
+      image: python:3.12-slim
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          apt-get update -qq && apt-get install -y -qq git curl jq procps >/dev/null && apt-get clean
+          pip install -q "git+https://github.com/ai-dynamo/aiperf.git@main"
+          pip install -q "sglang[runtime_common]==0.5.10.post1"
+          echo "aiperf + sglang.bench_serving installed and ready"
+          exec sleep infinity
+      envFrom:
+        - secretRef:
+            name: hf-token-secret
+      env:
+        - name: TARGET_MODEL
+          value: nvidia/Kimi-K2.5-NVFP4
+        - name: ENDPOINT
+          value: agg-sglang-kimi-k25-nvfp4-frontend.default.svc.cluster.local:8000
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: AIPERF_HTTP_CONNECTION_LIMIT
+          value: "2000"
+      resources:
+        requests: { cpu: "1", memory: "4Gi" }
+        limits:   { cpu: "4", memory: "16Gi" }
+      securityContext:
+        privileged: true
+      workingDir: /workspace

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/dgd-agg-sglang-kimi-k25-nvfp4-optimized.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/dgd-agg-sglang-kimi-k25-nvfp4-optimized.yaml
@@ -1,0 +1,282 @@
+# Dynamo aggregated deployment for Kimi K2.5 NVFP4 — optimized variant.
+#
+# Topology: 2-node TP=8 + PP=2 (same as the parity baseline / Standalone reference).
+# Engine config matches the parity DGD; the optimization stack adds Dynamo-side
+# capabilities for shared-prefix workloads:
+#   1. KV events ENABLED on Frontend → Dynamo router sees real-time cache state
+#   2. Radix cache enabled → high prefix-cache hit on shared-prefix workloads
+#   3. --enable-tokenizer-batch-encode → tokenizer CPU not a bottleneck at high concurrency
+#   4. --num-continuous-decode-steps 2 → reduce per-step Python overhead at high concurrency
+#   5. --kv-cache-dtype bfloat16 + --mem-fraction-static 0.82 (matches parity baseline)
+#
+# Apply with a shared-prefix benchmark workload to see Dynamo's KV-aware routing benefit.
+# Same DGD name as the parity baseline → swap with kubectl delete + apply.
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: agg-sglang-kimi-k25-nvfp4
+  namespace: default
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          command: ["python3"]
+          args:
+            - -m
+            - dynamo.frontend
+            - --router-mode
+            - kv                  # KV-aware routing (events enabled by default)
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    ModelExpress:
+      componentType: frontend
+      replicas: 1
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { cpu: "4", memory: 16Gi }
+        requests: { cpu: "1", memory: 4Gi }
+      livenessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 120
+        periodSeconds: 30
+        timeoutSeconds: 10
+        failureThreshold: 10
+      readinessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 60
+        periodSeconds: 15
+        timeoutSeconds: 10
+        failureThreshold: 10
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Starting Model Express Server..."
+              ./modelexpress-server &
+              SERVER_PID=$!
+
+              mkdir -p $MODEL_CACHE_PATH /model-cache/.model-express
+              cat > /model-cache/.model-express/config.yaml << EOF
+              local_path: $MODEL_CACHE_PATH
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              for i in $(seq 1 60); do
+                if ./modelexpress-cli --endpoint http://localhost:8000 health > /dev/null 2>&1; then
+                  echo "Server is ready"
+                  break
+                fi
+                sleep 2
+              done
+
+              echo "Downloading $MODEL_NAME ..."
+              ./modelexpress-cli --endpoint http://localhost:8000 \
+                --cache-path $MODEL_CACHE_PATH \
+                model download "$MODEL_NAME"
+
+              SNAPSHOT_DIR=$(ls -td $MODEL_CACHE_PATH/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/*/ 2>/dev/null | head -1)
+              if [ -n "$SNAPSHOT_DIR" ]; then
+                SNAPSHOTS_PARENT=$(dirname "$SNAPSHOT_DIR")
+                ln -sfn "$(basename "$SNAPSHOT_DIR")" "$SNAPSHOTS_PARENT/latest"
+              fi
+
+              wait $SERVER_PID
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: info
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: /model-cache/.model-express/cache
+            - name: MX_METADATA_BACKEND
+              value: redis
+            - name: REDIS_URL
+              value: redis://redis-master.default.svc.cluster.local:6379
+            - name: MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    agg:
+      componentType: worker
+      replicas: 1
+      # 2-node PP=2 single distributed worker — same topology as the parity baseline.
+      multinode:
+        nodeCount: 2
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { gpu: "8" }
+        requests: { gpu: "8" }
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-spot
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-preemptible
+            operator: Exists
+            effect: NoSchedule
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+          startupProbe:
+            httpGet: { path: /live, port: 9090 }
+            periodSeconds: 60
+            timeoutSeconds: 5
+            # 120 × 60s = 120 min. CUDA graph capture for Kimi NVFP4 + DP attention
+            # across many batch sizes can take 60-90+ minutes.
+            failureThreshold: 120
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              MODEL_NAME=nvidia/Kimi-K2.5-NVFP4
+              MODEL_DIR=/model-cache/.model-express/cache/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/latest
+
+              echo "Waiting for model snapshot at $MODEL_DIR ..."
+              for i in $(seq 1 1800); do
+                if [ -f "$MODEL_DIR/config.json" ]; then
+                  echo "Model snapshot ready."
+                  break
+                fi
+                sleep 2
+              done
+              if [ ! -f "$MODEL_DIR/config.json" ]; then
+                echo "ERROR: model snapshot not found at $MODEL_DIR"
+                exit 1
+              fi
+
+              # SGLang launch — same 2-node PP=2 topology as the parity baseline.
+              # + stacked optimizations on top of the parity baseline:
+              #   - fp8_e5m2 KV cache (halves per-token KV → 2× effective concurrency)
+              #   - mem-fraction 0.82 → 0.87 (~15% more KV pool)
+              #   - radix cache re-enabled (was --disable-radix-cache in baseline; we
+              #     re-enable for shared-prefix workload via run-benchmark-opt.sh)
+              #   - +--enable-tokenizer-batch-encode (reduces tokenizer CPU contention)
+              exec python3 -m dynamo.sglang \
+                --model-path "$MODEL_DIR" \
+                --served-model-name "$MODEL_NAME" \
+                --trust-remote-code \
+                --tensor-parallel-size 8 \
+                --pipeline-parallel-size 2 \
+                --dp-size 8 \
+                --enable-dp-attention \
+                --quantization modelopt_fp4 \
+                --disable-shared-experts-fusion \
+                --mem-fraction-static 0.82 \
+                --schedule-policy fcfs \
+                --chunked-prefill-size 16384 \
+                --kv-cache-dtype bfloat16 \
+                --reasoning-parser kimi_k2 \
+                --tool-call-parser kimi_k2 \
+                --enable-dp-lm-head \
+                --enable-fused-moe-sum-all-reduce \
+                --fp4-gemm-backend flashinfer_cutlass \
+                --attention-backend flashinfer \
+                --moe-runner-backend flashinfer_cutlass \
+                --enable-flashinfer-allreduce-fusion \
+                --disable-custom-all-reduce \
+                --enable-tokenizer-batch-encode \
+                --num-continuous-decode-steps 2 \
+                --enable-metrics \
+                --log-level info \
+                --host 0.0.0.0 \
+                --watchdog-timeout 3600
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: MODEL_EXPRESS_URL
+              value: http://agg-sglang-kimi-k25-nvfp4-modelexpress:8000
+            - name: TRITON_CACHE_DIR
+              value: /model-cache/.triton-cache
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0,eth1"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: SYS
+            - name: NCCL_SOCKET_NTHREADS
+              value: "8"
+            - name: NCCL_NSOCKS_PERTHREAD
+              value: "8"
+            - name: NCCL_MIN_NCHANNELS
+              value: "8"
+            - name: NCCL_ALLOC_P2P_NET_LL_BUFFERS
+              value: "1"
+            - name: SGLANG_ENABLE_JIT_DEEPGEMM
+              value: "0"
+            - name: SGLANG_ENABLE_DEEP_GEMM
+              value: "0"
+            - name: OMP_NUM_THREADS
+              value: "24"
+            - name: SGLANG_SET_CPU_AFFINITY
+              value: "1"
+            - name: SAFETENSORS_FAST_GPU
+              value: "1"
+            - name: PYTORCH_CUDA_ALLOC_CONF
+              value: "expandable_segments:True"
+            - name: FLASHINFER_DISABLE_VERSION_CHECK
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/dgd-agg-sglang-kimi-k25-nvfp4-parity.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/dgd-agg-sglang-kimi-k25-nvfp4-parity.yaml
@@ -1,0 +1,274 @@
+# Dynamo parity DGD — single replica with --router-mode random.
+#
+# Use this for the Dynamo-vs-Standalone parity comparison. Engine flags are
+# identical to the Standalone SGLang reference manifest; only the routing layer
+# differs (Dynamo Frontend wraps the engine).
+#
+# WHY RANDOM ROUTER AT replicas=1:
+# At single-instance, KV-aware routing has no value — there's only one worker
+# to route to. --router-mode random removes the router-side compute, isolating
+# just the Frontend HTTP layer for the parity measurement.
+#
+# APPLY:
+#   kubectl apply -f dgd-agg-sglang-kimi-k25-nvfp4-parity.yaml
+#   kubectl get pods -l nvidia.com/dynamo-graph-deployment-name=agg-sglang-kimi-k25-nvfp4 -w
+---
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: agg-sglang-kimi-k25-nvfp4
+  namespace: default
+spec:
+  services:
+    Frontend:
+      componentType: frontend
+      replicas: 1
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          command: ["python3"]
+          args:
+            - -m
+            - dynamo.frontend
+            - --router-mode
+            - random              # KV routing has no benefit at replicas=1; use random
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    ModelExpress:
+      componentType: frontend
+      replicas: 1
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { cpu: "4", memory: 16Gi }
+        requests: { cpu: "1", memory: 4Gi }
+      livenessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 120
+        periodSeconds: 30
+        timeoutSeconds: 10
+        failureThreshold: 10
+      readinessProbe:
+        tcpSocket: { port: 8000 }
+        initialDelaySeconds: 60
+        periodSeconds: 15
+        timeoutSeconds: 10
+        failureThreshold: 10
+      extraPodSpec:
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.3.0
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              echo "Starting Model Express Server..."
+              ./modelexpress-server &
+              SERVER_PID=$!
+
+              mkdir -p $MODEL_CACHE_PATH /model-cache/.model-express
+              cat > /model-cache/.model-express/config.yaml << EOF
+              local_path: $MODEL_CACHE_PATH
+              server_endpoint: http://localhost:8000
+              timeout_secs: null
+              EOF
+
+              for i in $(seq 1 60); do
+                if ./modelexpress-cli --endpoint http://localhost:8000 health > /dev/null 2>&1; then
+                  echo "Server is ready"
+                  break
+                fi
+                sleep 2
+              done
+
+              echo "Downloading $MODEL_NAME ..."
+              ./modelexpress-cli --endpoint http://localhost:8000 \
+                --cache-path $MODEL_CACHE_PATH \
+                model download "$MODEL_NAME"
+
+              SNAPSHOT_DIR=$(ls -td $MODEL_CACHE_PATH/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/*/ 2>/dev/null | head -1)
+              if [ -n "$SNAPSHOT_DIR" ]; then
+                SNAPSHOTS_PARENT=$(dirname "$SNAPSHOT_DIR")
+                ln -sfn "$(basename "$SNAPSHOT_DIR")" "$SNAPSHOTS_PARENT/latest"
+              fi
+
+              wait $SERVER_PID
+          env:
+            - name: MODEL_EXPRESS_SERVER_PORT
+              value: "8000"
+            - name: MODEL_EXPRESS_LOGGING_LEVEL
+              value: info
+            - name: MODEL_EXPRESS_CACHE_DIRECTORY
+              value: /model-cache/.model-express/cache
+            - name: MX_METADATA_BACKEND
+              value: redis
+            - name: REDIS_URL
+              value: redis://redis-master.default.svc.cluster.local:6379
+            - name: MODEL_NAME
+              value: nvidia/Kimi-K2.5-NVFP4
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache
+
+    agg:
+      componentType: worker
+      replicas: 1
+      # 2-node multinode worker, TP=8 + PP=2. Identical to parity DGD engine config.
+      # Grove injects --nnodes / --node-rank / --dist-init-addr.
+      multinode:
+        nodeCount: 2
+      envFromSecret: hf-token-secret
+      resources:
+        limits:   { gpu: "8" }
+        requests: { gpu: "8" }
+      sharedMemory:
+        size: 80Gi
+      extraPodSpec:
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        imagePullSecrets:
+          - name: nvcr-imagepullsecret
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+        tolerations:
+          - key: nvidia.com/gpu
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-spot
+            operator: Exists
+            effect: NoSchedule
+          - key: cloud.google.com/gke-preemptible
+            operator: Exists
+            effect: NoSchedule
+        mainContainer:
+          image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0
+          workingDir: /workspace
+          securityContext:
+            runAsUser: 0
+          startupProbe:
+            httpGet: { path: /live, port: 9090 }
+            periodSeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 60
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              MODEL_NAME=nvidia/Kimi-K2.5-NVFP4
+              MODEL_DIR=/model-cache/.model-express/cache/models--$(echo $MODEL_NAME | sed 's|/|--|g')/snapshots/latest
+
+              echo "Waiting for model snapshot at $MODEL_DIR ..."
+              for i in $(seq 1 1800); do
+                if [ -f "$MODEL_DIR/config.json" ]; then
+                  echo "Model snapshot ready."
+                  break
+                fi
+                sleep 2
+              done
+              if [ ! -f "$MODEL_DIR/config.json" ]; then
+                echo "ERROR: model snapshot not found at $MODEL_DIR"
+                exit 1
+              fi
+
+              # Engine launch — matches the Standalone SGLang reference flag-for-flag.
+              # Only the Frontend router mode differs (random vs kv) — see Frontend.args above.
+              exec python3 -m dynamo.sglang \
+                --model-path "$MODEL_DIR" \
+                --served-model-name "$MODEL_NAME" \
+                --trust-remote-code \
+                --tensor-parallel-size 8 \
+                --pipeline-parallel-size 2 \
+                --dp-size 8 \
+                --enable-dp-attention \
+                --quantization modelopt_fp4 \
+                --disable-shared-experts-fusion \
+                --mem-fraction-static 0.82 \
+                --schedule-policy fcfs \
+                --chunked-prefill-size 16384 \
+                --kv-cache-dtype bfloat16 \
+                --reasoning-parser kimi_k2 \
+                --tool-call-parser kimi_k2 \
+                --enable-dp-lm-head \
+                --enable-fused-moe-sum-all-reduce \
+                --disable-radix-cache \
+                --fp4-gemm-backend flashinfer_cutlass \
+                --attention-backend flashinfer \
+                --moe-runner-backend flashinfer_cutlass \
+                --enable-flashinfer-allreduce-fusion \
+                --disable-custom-all-reduce \
+                --host 0.0.0.0 \
+                --watchdog-timeout 3600
+          env:
+            - name: POD_UID
+              valueFrom: { fieldRef: { fieldPath: metadata.uid } }
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_HUB_CACHE
+              value: /model-cache/.model-express/cache
+            - name: MODEL_CACHE_PATH
+              value: /model-cache/.model-express/cache
+            - name: MODEL_EXPRESS_URL
+              value: http://agg-sglang-kimi-k25-nvfp4-modelexpress:8000
+            - name: TRITON_CACHE_DIR
+              value: /model-cache/.triton-cache
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0,eth1"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: SYS
+            - name: NCCL_SOCKET_NTHREADS
+              value: "8"
+            - name: NCCL_NSOCKS_PERTHREAD
+              value: "8"
+            - name: NCCL_MIN_NCHANNELS
+              value: "8"
+            - name: NCCL_ALLOC_P2P_NET_LL_BUFFERS
+              value: "1"
+            - name: SGLANG_ENABLE_JIT_DEEPGEMM
+              value: "0"
+            - name: SGLANG_ENABLE_DEEP_GEMM
+              value: "0"
+            - name: OMP_NUM_THREADS
+              value: "24"
+            - name: SGLANG_SET_CPU_AFFINITY
+              value: "1"
+            - name: SAFETENSORS_FAST_GPU
+              value: "1"
+            - name: PYTORCH_CUDA_ALLOC_CONF
+              value: "expandable_segments:True"
+            - name: FLASHINFER_DISABLE_VERSION_CHECK
+              value: "1"
+          volumeMounts:
+            - mountPath: /model-cache
+              name: model-cache
+        volumes:
+          - name: model-cache
+            persistentVolumeClaim:
+              claimName: model-cache

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/run-benchmark-natural-eos.sh
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/run-benchmark-natural-eos.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Natural-EOS benchmark for Kimi K2.5 NVFP4 -- matches Google reference methodology
+# exactly (variable OSL, EOS-terminated). Use this when you need an apples-to-apples
+# Dynamo-vs-Google throughput/TTFT comparison on the same workload Google ran.
+#
+# Difference vs run-benchmark.sh (locked OSL=8192, ignore_eos=true):
+#   - aiperf:        drops --extra-inputs ignore_eos:true
+#   - bench_serving: adds --disable-ignore-eos (this sglang version defaults ignore_eos=true)
+#
+# Expected (NVFP4, conc=512, 1536 reqs, ISL=1024, max OSL=8192 but natural EOS terminates):
+#   - OSL achieved avg: ~4,189 tokens (matches Google's 6,434,886 total / 1,536 reqs)
+#   - Duration: ~33 min (matches Google's 33.1 min)
+#   - Throughput: 3,200-3,400 tok/s for Dynamo (~tie with Google's 3,237 standalone)
+#   - TTFT P50: ~250-400 ms (matches Google's 304 ms standalone)
+#
+# Default harness per target (override with HARNESS=...):
+#   standalone -> bench_serving (matches Google reference command exactly)
+#   dynamo     -> aiperf        (Dynamo customer-facing harness)
+#
+# Usage:
+#   ./run-benchmark-natural-eos.sh standalone                  # Google-methodology standalone
+#   ./run-benchmark-natural-eos.sh dynamo                      # Dynamo at Google methodology
+#   HARNESS=bench ./run-benchmark-natural-eos.sh dynamo        # bench cross-check on Dynamo
+#   ./run-benchmark-natural-eos.sh <full-url>
+
+set -euo pipefail
+
+TARGET=${1:-dynamo}
+case "$TARGET" in
+  standalone) DEFAULT_HARNESS=bench ;;
+  *)          DEFAULT_HARNESS=aiperf ;;
+esac
+HARNESS=${HARNESS:-$DEFAULT_HARNESS}
+
+case "$TARGET" in
+  dynamo)
+    URL="http://agg-sglang-kimi-k25-nvfp4-frontend.default.svc.cluster.local:8000"
+    TAG="dynamo"
+    ;;
+  standalone)
+    URL="http://kimi-k25-sglang-nvfp4-serving.default.svc.cluster.local:8000"
+    TAG="standalone"
+    ;;
+  http*)
+    URL="$TARGET"
+    TAG="custom"
+    ;;
+  *)
+    echo "Usage: $0 [dynamo|standalone|<url>]   (env: HARNESS=aiperf|bench)" >&2
+    exit 1
+    ;;
+esac
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/workspace/results/kimi-k25-nvfp4-c512-1536req-${TAG}-natEOS-${HARNESS}}
+mkdir -p "$ARTIFACT_DIR"
+
+echo "==> Natural-EOS methodology (variable OSL, matches Google reference)"
+echo "==> Target=${TARGET} (${URL}); Harness=${HARNESS}"
+echo "==> Artifacts: ${ARTIFACT_DIR}"
+
+if [[ "$HARNESS" == "aiperf" ]]; then
+  # Random workload, ISL=1024, max OSL=8192 but no ignore_eos -> Kimi EOS terminates
+  # at ~4,189 avg OSL (same as Google's reference run).
+  aiperf profile \
+    --model nvidia/Kimi-K2.5-NVFP4 \
+    --url "$URL" \
+    --endpoint-type chat \
+    --streaming \
+    --tokenizer nvidia/Kimi-K2.5-NVFP4 \
+    --tokenizer-trust-remote-code \
+    --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 \
+    --output-tokens-mean 8192 --output-tokens-stddev 0 \
+    --num-prompts 1536 --num-requests 1536 \
+    --concurrency 512 \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --ui simple
+else
+  HOST_PORT=${URL#http://}
+  HOST_PORT=${HOST_PORT#https://}
+  HOST=${HOST_PORT%:*}
+  PORT=${HOST_PORT##*:}
+
+  # bench_serving's default in this sglang version is ignore_eos=true; explicitly
+  # disable it to match Google's natural-EOS methodology.
+  python3 -m sglang.bench_serving \
+    --backend sglang-oai \
+    --host "$HOST" --port "$PORT" \
+    --model nvidia/Kimi-K2.5-NVFP4 \
+    --tokenizer nvidia/Kimi-K2.5-NVFP4 \
+    --dataset-name random \
+    --random-input-len 1024 --random-output-len 8192 \
+    --num-prompts 1536 \
+    --max-concurrency 512 \
+    --apply-chat-template \
+    --disable-ignore-eos \
+    --output-file "$ARTIFACT_DIR/bench_serving.json"
+fi
+
+echo "Results in: $ARTIFACT_DIR"

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/run-benchmark-optimized.sh
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/run-benchmark-optimized.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Optimized Dynamo benchmark for Kimi K2.5 NVFP4 — shared-prefix workload.
+#
+# Pairs with dgd-agg-sglang-kimi-k25-nvfp4-optimized.yaml (KV-aware routing +
+# radix cache). Default workload is 80% shared prefix — empirically the best
+# TTFT-P99 sweet spot for Kimi K2.5 NVFP4 on RTX PRO 6000 at conc=512:
+#   - more unique tokens per request (~204) keep chunked-prefill kernels well-fed
+#   - smaller per-prefix size (~820 tokens) reduces eviction churn under load
+#
+# Override the split via SHARED_PERCENT env var:
+#   - 80 (default; recommended)  : 820 prefix + 204 unique. ISL=1024.
+#   - 98 (max shared)            : 1024 prefix + 16 unique. ISL=1040.
+#   - 50                         : 512 prefix + 512 unique. ISL=1024.
+#   - 0  (near-random)           : 1 + 1023.
+#
+# Default harness per target (override with HARNESS=...):
+#   dynamo     -> aiperf         (radix-cache warmup methodology; primary metric)
+#   standalone -> bench_serving  (Google-comparable methodology)
+#
+# Usage:
+#   ./run-benchmark-optimized-shared.sh dynamo                       # 80% shared (default)
+#   SHARED_PERCENT=98 ./run-benchmark-optimized-shared.sh dynamo     # 98% shared
+#   SHARED_PERCENT=80 HARNESS=bench ./run-benchmark-optimized-shared.sh dynamo
+#   ./run-benchmark-optimized-shared.sh <full-url>                   # custom endpoint
+
+set -euo pipefail
+
+TARGET=${1:-dynamo}
+case "$TARGET" in
+  standalone) DEFAULT_HARNESS=bench ;;
+  *)          DEFAULT_HARNESS=aiperf ;;
+esac
+HARNESS=${HARNESS:-$DEFAULT_HARNESS}
+
+case "$TARGET" in
+  dynamo)
+    URL="http://agg-sglang-kimi-k25-nvfp4-frontend.default.svc.cluster.local:8000"
+    TAG="dynamo"
+    ;;
+  standalone)
+    URL="http://kimi-k25-sglang-nvfp4-serving.default.svc.cluster.local:8000"
+    TAG="standalone"
+    ;;
+  http*)
+    URL="$TARGET"
+    TAG="custom"
+    ;;
+  *)
+    echo "Usage: $0 [dynamo|standalone|<url>]   (env: HARNESS=aiperf|bench  SHARED_PERCENT=80|98|50|0)" >&2
+    exit 1
+    ;;
+esac
+
+# Shared-prefix workload composition — total ISL ~1024 tokens, split prefix vs unique tail.
+SHARED_PERCENT=${SHARED_PERCENT:-80}
+TARGET_ISL=1024
+
+case "$SHARED_PERCENT" in
+  98) PREFIX_LEN=1024; SYNTHETIC=16 ;;
+  80) PREFIX_LEN=820;  SYNTHETIC=204 ;;     # recommended sweet spot
+  50) PREFIX_LEN=512;  SYNTHETIC=512 ;;
+  0)  PREFIX_LEN=1;    SYNTHETIC=1023 ;;
+  *)
+    PREFIX_LEN=$(( TARGET_ISL * SHARED_PERCENT / 100 ))
+    SYNTHETIC=$(( TARGET_ISL - PREFIX_LEN ))
+    ;;
+esac
+
+POOL_SIZE=64
+WARMUP_COUNT=$(( POOL_SIZE * 2 ))   # 2x pool so every prefix is warmed into radix cache
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/workspace/results/kimi-k25-nvfp4-c512-1536req-${TAG}-opt-${HARNESS}-shared${SHARED_PERCENT}}
+mkdir -p "$ARTIFACT_DIR"
+
+echo "==> Shared prefix=${SHARED_PERCENT}% (prefix=${PREFIX_LEN}, unique=${SYNTHETIC}); pool=${POOL_SIZE}; warmup=${WARMUP_COUNT}"
+echo "==> Target=${TARGET} (${URL}); Harness=${HARNESS}"
+echo "==> Artifacts: ${ARTIFACT_DIR}"
+
+if [[ "$HARNESS" == "aiperf" ]]; then
+  aiperf profile \
+    --model nvidia/Kimi-K2.5-NVFP4 \
+    --url "$URL" \
+    --endpoint-type chat \
+    --streaming \
+    --tokenizer nvidia/Kimi-K2.5-NVFP4 \
+    --tokenizer-trust-remote-code \
+    --prefix-prompt-length "$PREFIX_LEN" \
+    --prefix-prompt-pool-size "$POOL_SIZE" \
+    --synthetic-input-tokens-mean "$SYNTHETIC" --synthetic-input-tokens-stddev 0 \
+    --output-tokens-mean 8192 --output-tokens-stddev 0 \
+    --num-prompts 1536 --num-requests 1536 \
+    --warmup-request-count "$WARMUP_COUNT" \
+    --use-server-token-count \
+    --concurrency 512 \
+    --record-processors 16 \
+    --random-seed 100 \
+    --extra-inputs ignore_eos:true \
+    --extra-inputs max_tokens:8192 \
+    --extra-inputs min_tokens:8192 \
+    --extra-inputs temperature:0.0 \
+    --extra-inputs repetition_penalty:1.0 \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --ui simple
+else
+  HOST_PORT=${URL#http://}
+  HOST_PORT=${HOST_PORT#https://}
+  HOST=${HOST_PORT%:*}
+  PORT=${HOST_PORT##*:}
+
+  PROMPTS_PER_GROUP=$(( 1536 / POOL_SIZE ))   # 24 for pool=64
+  python3 -m sglang.bench_serving \
+    --backend sglang-oai \
+    --host "$HOST" --port "$PORT" \
+    --model nvidia/Kimi-K2.5-NVFP4 \
+    --tokenizer nvidia/Kimi-K2.5-NVFP4 \
+    --dataset-name generated-shared-prefix \
+    --gsp-num-groups "$POOL_SIZE" \
+    --gsp-prompts-per-group "$PROMPTS_PER_GROUP" \
+    --gsp-system-prompt-len "$PREFIX_LEN" \
+    --gsp-question-len "$SYNTHETIC" \
+    --gsp-output-len 8192 \
+    --max-concurrency 512 \
+    --warmup-requests "$WARMUP_COUNT" \
+    --apply-chat-template \
+    --seed 100 \
+    --extra-request-body '{"ignore_eos":true,"min_tokens":8192,"max_tokens":8192,"temperature":0.0,"repetition_penalty":1.0}' \
+    --output-file "$ARTIFACT_DIR/bench_serving.json"
+fi
+
+echo "Results in: $ARTIFACT_DIR"

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/run-benchmark-parity.sh
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/run-benchmark-parity.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Dynamo-vs-Standalone parity benchmark — apples-to-apples comparison.
+#
+# WHY THIS SCRIPT EXISTS:
+# To answer "is Dynamo on par with Standalone SGLang at single-instance?" without
+# methodology noise, we run the SAME aiperf command against both endpoints with:
+#   - aiperf on both sides       (no harness instrumentation drift)
+#   - LOCKED OSL=8192 (ignore_eos=true + min/max_tokens=8192)
+#                                (eliminates EOS-distribution variance; engine
+#                                 runs in steady-state decode where Dynamo
+#                                 overhead is most visible)
+#   - random workload            (no shared prefix -- KV routing has no effect)
+#   - deterministic sampling     (temperature=0, rep_penalty=1.0, random-seed=100)
+#   - same engine config         (Standalone manifest = Dynamo DGD engine flags)
+# Any leftover delta is Dynamo's Frontend / service-mesh / router overhead.
+#
+# PREREQUISITES:
+#   1. Dynamo parity DGD applied (random router):
+#      kubectl apply -f dgd-agg-sglang-kimi-k25-nvfp4-parity.yaml
+#      (Uses --router-mode random; KV routing has no benefit at replicas=1.)
+#   2. Standalone NVFP4 deployment ALSO running for the standalone leg:
+#      kubectl apply -f standalone-sglang-kimi-k25-nvfp4.yaml
+#      (They share the model-cache PVC; OK to have both deployed simultaneously.)
+#   3. Perf pod running:
+#      kubectl apply -f benchmark-kimi-k25-nvfp4-pod.yaml
+#
+# USAGE:
+#   ./run-benchmark-parity.sh standalone                 # aiperf vs Standalone (default)
+#   ./run-benchmark-parity.sh dynamo                     # aiperf vs Dynamo (default)
+#   HARNESS=bench  ./run-benchmark-parity.sh dynamo      # bench_serving cross-check vs Dynamo
+#   HARNESS=bench  ./run-benchmark-parity.sh standalone  # bench_serving cross-check vs Standalone
+#   HARNESS=aiperf ./run-benchmark-parity.sh dynamo      # explicit aiperf (same as default)
+#   ./run-benchmark-parity.sh <full-url>                 # custom endpoint
+#
+# Run both targets sequentially (don't overlap on same cluster).
+# Each run ~21-35 min wall time.
+#
+# Note: this aiperf-based parity run is NOT directly comparable to Google's published
+# 3,237 tok/s number (Google used bench_serving). Use this for Dynamo-vs-Standalone
+# apples-to-apples; for Google-comparable Standalone numbers, use bench_serving.
+
+set -euo pipefail
+
+TARGET=${1:-dynamo}
+HARNESS=${HARNESS:-aiperf}      # default aiperf; override with HARNESS=bench for sglang.bench_serving
+
+case "$TARGET" in
+  dynamo)
+    URL="http://agg-sglang-kimi-k25-nvfp4-frontend.default.svc.cluster.local:8000"
+    TAG="dynamo"
+    ;;
+  standalone)
+    URL="http://kimi-k25-sglang-nvfp4-serving.default.svc.cluster.local:8000"
+    TAG="standalone"
+    ;;
+  http*)
+    URL="$TARGET"
+    TAG="custom"
+    ;;
+  *)
+    echo "Usage: $0 [dynamo|standalone|<url>]   (env: HARNESS=aiperf|bench)" >&2
+    exit 1
+    ;;
+esac
+
+ARTIFACT_DIR=${ARTIFACT_DIR:-/workspace/results/kimi-k25-nvfp4-c512-1536req-${TAG}-parity-${HARNESS}}
+mkdir -p "$ARTIFACT_DIR"
+
+echo "==> Parity test (${HARNESS}, LOCKED OSL=8192, random workload, deterministic sampling)"
+echo "==> Target=${TARGET} (${URL})"
+echo "==> Artifacts: ${ARTIFACT_DIR}"
+
+# aiperf with:
+#   - ISL=1024 (locked synthetic input length)
+#   - OSL=8192 LOCKED via ignore_eos + min_tokens=max_tokens=8192
+#       (every request generates exactly 8192 tokens -- removes EOS variance,
+#        engine runs in steady-state decode, Dynamo overhead most visible)
+#   - random prompts (no --prefix-prompt-* flags) -> no shared prefix
+#   - conc=512, 1536 requests -> matches Google reference workload sizing
+#   - Deterministic sampling (temperature=0, rep_penalty=1.0) + random-seed=100
+#     -> reproducible across runs
+if [[ "$HARNESS" == "aiperf" ]]; then
+  aiperf profile \
+    --model nvidia/Kimi-K2.5-NVFP4 \
+    --url "$URL" \
+    --endpoint-type chat \
+    --streaming \
+    --tokenizer nvidia/Kimi-K2.5-NVFP4 \
+    --tokenizer-trust-remote-code \
+    --synthetic-input-tokens-mean 1024 --synthetic-input-tokens-stddev 0 \
+    --output-tokens-mean 8192 --output-tokens-stddev 0 \
+    --num-prompts 1536 --num-requests 1536 \
+    --use-server-token-count \
+    --concurrency 512 \
+    --record-processors 16 \
+    --random-seed 100 \
+    --extra-inputs ignore_eos:true \
+    --extra-inputs max_tokens:8192 \
+    --extra-inputs min_tokens:8192 \
+    --extra-inputs temperature:0.0 \
+    --extra-inputs repetition_penalty:1.0 \
+    --artifact-dir "$ARTIFACT_DIR" \
+    --ui simple
+else
+  # bench_serving cross-check path -- random workload, locked OSL=8192, deterministic sampling.
+  # Mirrors the aiperf path's methodology for harness cross-validation.
+  HOST_PORT=${URL#http://}
+  HOST_PORT=${HOST_PORT#https://}
+  HOST=${HOST_PORT%:*}
+  PORT=${HOST_PORT##*:}
+
+  python3 -m sglang.bench_serving \
+    --backend sglang-oai \
+    --host "$HOST" --port "$PORT" \
+    --model nvidia/Kimi-K2.5-NVFP4 \
+    --tokenizer nvidia/Kimi-K2.5-NVFP4 \
+    --dataset-name random \
+    --random-input-len 1024 --random-output-len 8192 \
+    --num-prompts 1536 \
+    --max-concurrency 512 \
+    --apply-chat-template \
+    --seed 100 \
+    --extra-request-body '{"ignore_eos":true,"min_tokens":8192,"max_tokens":8192,"temperature":0.0,"repetition_penalty":1.0}' \
+    --output-file "$ARTIFACT_DIR/bench_serving.json"
+fi
+
+echo "Results in: $ARTIFACT_DIR"

--- a/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/standalone-sglang-kimi-k25-nvfp4.yaml
+++ b/dynamo-samples/dynamo-g4/kimi-k25-nvfp4/standalone-sglang-kimi-k25-nvfp4.yaml
@@ -1,0 +1,164 @@
+# Raw SGLang baseline for Kimi K2.5 NVFP4 — 2-node g4 (RTX PRO 6000) GKE cluster.
+# Mirrors https://github.com/shivajid/sglang-rtx-pro-6000/blob/main/models/KimiK2.5/nvfp4/sglang-kimi-nvfp4-2node.yaml
+# flag-for-flag. Topology: TP=8 + PP=2 across 2 g4-standard-384 nodes as one
+# distributed SGLang worker (StatefulSet replicas=2 = the two pods of that worker).
+#
+# Why 2 nodes when NVFP4 (~370 GB) fits on 1: 2× KV cache pool capacity for OSL=8192
+# / conc=512 workloads, matching Google's reference topology for apples-to-apples
+# comparison with both the Standalone reference and the Dynamo parity DGD.
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kimi-k25-sglang-nvfp4
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kimi-k25-sglang-nvfp4
+  serviceName: "kimi-k25-sglang-nvfp4-master"
+  template:
+    metadata:
+      labels:
+        app: kimi-k25-sglang-nvfp4
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: cloud.google.com/gke-spot
+          operator: Exists
+          effect: NoSchedule
+        - key: cloud.google.com/gke-preemptible
+          operator: Exists
+          effect: NoSchedule
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: sglang
+          image: docker.io/lmsysorg/sglang:v0.5.10.post1 #docker.io/lmsysorg/sglang:dev-cu13
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+              python3 -m sglang.launch_server \
+                --model nvidia/Kimi-K2.5-NVFP4 \
+                --tensor-parallel-size 8 \
+                --pipeline-parallel-size 2 \
+                --dp-size 8 \
+                --enable-dp-attention \
+                --nnodes 2 \
+                --node-rank $POD_INDEX \
+                --port 8000 \
+                --dist-init-addr kimi-k25-sglang-nvfp4-master:5000 \
+                --trust-remote-code \
+                --quantization modelopt_fp4 \
+                --disable-shared-experts-fusion \
+                --mem-fraction-static 0.82 \
+                --schedule-policy fcfs \
+                --chunked-prefill-size 16384 \
+                --kv-cache-dtype bfloat16 \
+                --reasoning-parser kimi_k2 \
+                --tool-call-parser kimi_k2 \
+                --enable-dp-lm-head \
+                --enable-fused-moe-sum-all-reduce \
+                --disable-radix-cache \
+                --fp4-gemm-backend flashinfer_cutlass \
+                --attention-backend flashinfer \
+                --moe-runner-backend flashinfer_cutlass \
+                --enable-flashinfer-allreduce-fusion \
+                --disable-custom-all-reduce \
+                --host 0.0.0.0
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+            - name: POD_INDEX
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+            # NCCL — cross-node PP traffic uses eth0,eth1 on multi-NIC g4 nodes.
+            - name: NCCL_DEBUG
+              value: INFO
+            - name: NCCL_SOCKET_IFNAME
+              value: "eth0,eth1"
+            - name: NCCL_IB_DISABLE
+              value: "1"
+            - name: NCCL_P2P_LEVEL
+              value: SYS
+            - name: NCCL_SOCKET_NTHREADS
+              value: "8"
+            - name: NCCL_NSOCKS_PERTHREAD
+              value: "8"
+            - name: NCCL_MIN_NCHANNELS
+              value: "8"
+            - name: NCCL_ALLOC_P2P_NET_LL_BUFFERS
+              value: "1"
+            - name: OMP_NUM_THREADS
+              value: "24"
+            - name: SGLANG_SET_CPU_AFFINITY
+              value: "1"
+            - name: SAFETENSORS_FAST_GPU
+              value: "1"
+            - name: PYTORCH_CUDA_ALLOC_CONF
+              value: "expandable_segments:True"
+            - name: SGLANG_ENABLE_DEEP_GEMM
+              value: "0"
+            - name: SGLANG_ENABLE_JIT_DEEPGEMM
+              value: "0"
+          resources:
+            limits:
+              nvidia.com/gpu: "8"
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /root/.cache/huggingface
+              name: hf-cache
+          securityContext:
+            privileged: true
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Gi
+        - name: hf-cache
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25-sglang-nvfp4-serving
+spec:
+  type: ClusterIP
+  selector:
+    app: kimi-k25-sglang-nvfp4
+    apps.kubernetes.io/pod-index: "0"
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+    - name: metrics
+      port: 8080
+      targetPort: 8080
+---
+# Headless service for SGLang distributed init (pod-0 acts as master, pod-1 connects in).
+apiVersion: v1
+kind: Service
+metadata:
+  name: kimi-k25-sglang-nvfp4-master
+spec:
+  clusterIP: None
+  selector:
+    app: kimi-k25-sglang-nvfp4
+    apps.kubernetes.io/pod-index: "0"
+  ports:
+    - name: dist-port
+      port: 5000
+      targetPort: 5000


### PR DESCRIPTION
## Summary

NVIDIA Dynamo + SGLang reference deployment for **Kimi K2.5** (NVFP4 and Native INT4) on Google Cloud's `g4-standard-384` instance (8× RTX PRO 6000 Blackwell, SM_120). Two-node GKE topology with TP=8 + PP=2, matched flag-for-flag to Google's published Kimi K2.5 reference, and pinned to SGLang `v0.5.10.post1` (the version Dynamo's certified `sglang-runtime:1.1.0` image bundles) so every Dynamo-vs-Standalone comparison holds the SGLang code constant.

## What's added (17 files under `dynamo-samples/dynamo-g4/`)

| Path | Purpose |
|---|---|
| `README.md` | Entry point — links to NVFP4 and INT4 subdirs |
| `kimi-k25-nvfp4/` | NVFP4 quant: ~370 GB weights, bf16 KV, mem-fraction 0.82, DP attention (dp-size=8), FlashInfer NVFP4 CUTLASS |
| `kimi-k25-int4/` | Native INT4 quant: ~700 GB weights, fp8_e5m2 KV, mem-fraction 0.85, no DP attention, CompressedTensors WNA16 Marlin MoE |

Each quant directory ships the same 7 files:

- `standalone-sglang-kimi-k25-<quant>.yaml` — bare SGLang `StatefulSet` matching Google's published reference flag-for-flag (Goal 1 baseline)
- `dgd-agg-sglang-kimi-k25-<quant>.yaml` — Dynamo aggregated `DynamoGraphDeployment` with `--router-mode random` for Goal 2 parity (KV routing has no benefit at 1 replica; random isolates Frontend / HTTP / service-mesh overhead from the engine)
- `dgd-agg-sglang-kimi-k25-<quant>-optimized.yaml` — template DGD with KV-aware router + radix cache + KV events for shared-prefix workloads (Goal 3 work in progress)
- `benchmark-kimi-k25-<quant>-pod.yaml` — `aiperf` + `sglang.bench_serving` client pod
- `run-benchmark-natural-eos.sh` — variable OSL via `bench_serving` (Google's published methodology, Goal 1)
- `run-benchmark-parity.sh` — `aiperf` locked OSL=8192 with deterministic sampling (Goal 2 apples-to-apples vs Standalone)
- `run-benchmark-optimized.sh` — shared-prefix benchmark for optimized DGD (Goal 3 template, default 80% shared prefix, configurable via `SHARED_PERCENT`)

## Goals demonstrated

- **Goal 1 — match Google reference**: NVIDIA Standalone matches and exceeds Google's published `bench_serving` variable-OSL numbers on both quants (NVFP4 +4.2% TPS / -2.5% ITL P50; INT4 +14.8% TPS / -1.4% ITL P50)
- **Goal 2 — Dynamo parity vs Standalone**: with locked OSL=8192 + random router + clean methodology, Dynamo wrapper overhead is within ~6% on NVFP4 and beats Standalone on INT4 (+6.7% TPS / -7.9% ITL P50)
- **Goal 3 — Dynamo optimized (WIP)**: KV-aware router + radix cache template provided; intended for multi-replica deployments where shared-prefix workloads exercise Dynamo's primary value-add

## Architecture context

- Multi-NIC GKE cluster with jumbo MTU 8896 and 32× local NVMe SSD per node — matches Google's reference topology
- `hostNetwork: true` on the GPU worker so `NCCL_SOCKET_IFNAME=eth0,eth1` engages both gVNICs for cross-node PP send/recv
- Filestore RWX PVC for shared model cache + Triton cache (`TRITON_CACHE_DIR=/model-cache/.triton-cache`)
- ModelExpress server caches the gated HuggingFace weights once for shared access across worker pods

## References

- Google's published Kimi K2.5 NVFP4 reference: <https://github.com/shivajid/sglang-rtx-pro-6000/tree/main/models/KimiK2.5/nvfp4>
- Google's published Kimi K2.5 INT4 reference: <https://github.com/shivajid/sglang-rtx-pro-6000/tree/main/models/KimiK2.5>

## Test plan

- [x] Standalone NVFP4 + INT4 deploy and serve on `g4-dynamo-mn` GKE cluster (us-south1)
- [x] Dynamo parity DGD (NVFP4 + INT4) deploys via `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.0` and serves identical workload
- [x] `bench_serving` variable-OSL run matches Google's published TPS/TTFT/ITL (Goal 1) on both quants
- [x] `aiperf` locked OSL=8192 parity run measures Dynamo wrapper overhead on the same engine config (Goal 2) on both quants
- [x] Optimized DGD + shared-prefix benchmark script verified to launch and produce KV-router results (Goal 3 template)
- [ ] Multi-replica KV-routing demonstration on a larger GPU pool (Goal 3 production — separate follow-up PR)