### PR TITLE
Add use case root README indexes

### DIFF
--- a/agentic/README.md
+++ b/agentic/README.md
@@ -1,0 +1,9 @@
+# Agentic
+
+Agentic samples for building and deploying NVIDIA-powered agent workflows on Google Cloud.
+
+Samples in this use case are organized by Google Cloud service, then by NVIDIA library or stack.
+
+## Samples
+
+- [Agent Platform / AIQ](agent-platform/aiq)

--- a/data-processing/README.md
+++ b/data-processing/README.md
@@ -1,0 +1,11 @@
+# Data Processing
+
+Data processing samples for GPU-accelerated analytics, batch inference, and pipeline workloads on Google Cloud.
+
+Samples in this use case are organized by Google Cloud service, then by NVIDIA library or stack.
+
+## Samples
+
+- [BigQuery / RAPIDS](bigquery/rapids)
+- [Dataflow / TensorFlow](dataflow/tensorflow)
+- [Dataflow / TensorRT](dataflow/tensorrt)

--- a/industry-solutions/README.md
+++ b/industry-solutions/README.md
@@ -1,0 +1,11 @@
+# Industry Solutions
+
+Industry solution samples and NVIDIA blueprint deployments on Google Cloud.
+
+Samples in this use case are organized by Google Cloud service, then by NVIDIA library, blueprint, or solution stack.
+
+## Samples
+
+- [Compute Engine / Video Search and Summarization](compute-engine/video-search-and-summarization)
+- [GKE / BioNeMo Drug Discovery](gke/bionemo-drug-discovery)
+- [GKE / RAG](gke/rag)

--- a/inference/README.md
+++ b/inference/README.md
@@ -1,0 +1,15 @@
+# Inference
+
+Inference samples for deploying NVIDIA NIM, Triton, Dynamo, and related model-serving stacks on Google Cloud.
+
+Samples in this use case are organized by Google Cloud service, then by NVIDIA library or stack.
+
+## Samples
+
+- [Agent Platform / NIM](agent-platform/nim)
+- [Agent Platform / Triton](agent-platform/triton)
+- [Cloud Run / NIM](cloud-run/nim)
+- [GKE / Dynamo](gke/dynamo)
+- [GKE / NIM](gke/nim)
+- [GKE / TAO and Triton](gke/tao-triton)
+- [GKE / Triton](gke/triton)

--- a/physical-ai/README.md
+++ b/physical-ai/README.md
@@ -1,0 +1,9 @@
+# Physical AI
+
+Physical AI samples for robotics, simulation, and embodied AI workflows on Google Cloud.
+
+Samples in this use case are organized by Google Cloud service, then by NVIDIA library or stack.
+
+## Samples
+
+- [Compute Engine / Isaac Lab and Newton](compute-engine/isaac-lab-newton)

--- a/training/README.md
+++ b/training/README.md
@@ -1,0 +1,10 @@
+# Training
+
+Training samples for NVIDIA-accelerated model development and optimization workflows on Google Cloud.
+
+Samples in this use case are organized by Google Cloud service, then by NVIDIA library or stack.
+
+## Samples
+
+- [Agent Platform / NeMo RL](agent-platform/nemo-rl)
+- [Agent Platform / RAPIDS](agent-platform/rapids)


### PR DESCRIPTION
## Summary
- Add README indexes under each top-level use-case folder
- Link each root folder to its current Google Cloud service subfolders
- Prevent GitHub from compacting single-child root folders into long paths in the repository root view

## Validation
- Root README local links resolve