### PR TITLE
Add vLLM Inference Gateway recipe

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -13,3 +13,4 @@ Samples in this use case are organized by Google Cloud service, then by NVIDIA l
 - [GKE / NIM](gke/nim)
 - [GKE / TAO and Triton](gke/tao-triton)
 - [GKE / Triton](gke/triton)
+- [GKE / vLLM Inference Gateway](gke/vllm-inference-gateway)

--- a/inference/gke/vllm-inference-gateway/README.md
+++ b/inference/gke/vllm-inference-gateway/README.md
@@ -1,0 +1,264 @@
+# vLLM Inference Gateway on GKE
+
+Deploy two OpenAI-compatible vLLM model servers on GKE Autopilot and expose them through one GKE Inference Gateway endpoint. The sample routes requests by the `model` value in the JSON body:
+
+- `google/gemma-4-E2B-it` routes to a Gemma vLLM server.
+- `nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16` routes to a NVIDIA Nemotron vLLM server.
+
+Both model servers request one `2g.48gb` MIG partition on an NVIDIA RTX PRO 6000 GPU. The Nemotron pod uses pod affinity to run on the same physical node as the Gemma pod, so the two servers share one physical GPU through separate MIG slices.
+
+## Prerequisites
+
+- A Google Cloud project with billing enabled.
+- Quota for one NVIDIA RTX PRO 6000 GPU in the target region.
+- `gcloud`, `kubectl`, `helm`, `curl`, and `jq`.
+- A Hugging Face read token with access to:
+  - https://huggingface.co/google/gemma-4-E2B-it
+  - https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
+
+## Configure environment
+
+```bash
+export PROJECT_ID=<your-project-id>
+export REGION=us-central1
+export CLUSTER_NAME=vllm-inference
+export NETWORK=default
+export SUBNET=default
+export HF_TOKEN=<your-hugging-face-token>
+
+gcloud config set project ${PROJECT_ID}
+```
+
+Enable required Google Cloud APIs:
+
+```bash
+gcloud services enable \
+  compute.googleapis.com \
+  container.googleapis.com \
+  networkservices.googleapis.com \
+  logging.googleapis.com \
+  monitoring.googleapis.com
+```
+
+Create a proxy-only subnet for the regional external Application Load Balancer used by the Gateway:
+
+```bash
+gcloud compute networks subnets create ${REGION}-proxy-only-subnet \
+  --purpose=REGIONAL_MANAGED_PROXY \
+  --role=ACTIVE \
+  --region=${REGION} \
+  --network=${NETWORK} \
+  --range=10.0.200.0/23
+```
+
+Create an Autopilot cluster with GKE Gateway API and managed workload monitoring:
+
+```bash
+gcloud container clusters create-auto ${CLUSTER_NAME} \
+  --project=${PROJECT_ID} \
+  --region=${REGION} \
+  --network=${NETWORK} \
+  --subnetwork=${SUBNET} \
+  --release-channel=rapid \
+  --gateway-api=standard \
+  --auto-monitoring-scope=ALL
+
+gcloud container clusters get-credentials ${CLUSTER_NAME} \
+  --region=${REGION} \
+  --project=${PROJECT_ID}
+```
+
+Install the Inference Gateway CRDs:
+
+```bash
+kubectl apply -f \
+  https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.3.1/manifests.yaml
+```
+
+Install the custom metrics adapter and grant it Monitoring Viewer access. This is required by the sample HPA resources that read InferencePool metrics.
+
+```bash
+kubectl apply -f \
+  https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-stackdriver/master/custom-metrics-stackdriver-adapter/deploy/production/adapter_new_resource_model.yaml
+
+PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')
+
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --role=roles/monitoring.viewer \
+  --member=principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${PROJECT_ID}.svc.id.goog/subject/ns/custom-metrics/sa/custom-metrics-stackdriver-adapter
+```
+
+Create the Hugging Face token secret:
+
+```bash
+kubectl create secret generic hf-secret \
+  --from-literal=hf_api_token=${HF_TOKEN} \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+## Deploy vLLM model servers
+
+From this directory:
+
+```bash
+kubectl apply -f manifests/vllm-gemma.yaml
+kubectl wait deploy/vllm-gemma-4-e2b --for=condition=Available --timeout=15m
+
+kubectl apply -f manifests/vllm-nemotron.yaml
+kubectl wait deploy/vllm-nemotron-nano-4b --for=condition=Available --timeout=15m
+```
+
+Check the pods:
+
+```bash
+kubectl get pods -l app=vllm-gemma-4-e2b
+kubectl get pods -l app=vllm-nemotron-nano-4b
+```
+
+## Deploy Inference Gateway
+
+Install the body-based routing extension. It reads the `model` field from OpenAI-compatible requests and sets the `X-Gateway-Model-Name` header used by the HTTPRoutes.
+
+```bash
+helm upgrade --install bbr \
+  --version v1.3.1 \
+  --set provider.name=gke \
+  --set inferenceGateway.name=vllm-xlb \
+  oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing
+```
+
+Install one InferencePool per model server:
+
+```bash
+helm upgrade --install vllm-gemma-4-e2b \
+  --dependency-update \
+  --set inferencePool.modelServers.matchLabels.app=vllm-gemma-4-e2b \
+  --set provider.name=gke \
+  --version v1.3.1 \
+  oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+  -f epp-values.yaml
+
+helm upgrade --install vllm-nemotron-nano-4b \
+  --dependency-update \
+  --set inferencePool.modelServers.matchLabels.app=vllm-nemotron-nano-4b \
+  --set provider.name=gke \
+  --version v1.3.1 \
+  oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool \
+  -f epp-values.yaml
+```
+
+Apply the InferenceObjectives, Gateway, and HTTPRoutes:
+
+```bash
+kubectl apply -f manifests/inference-objectives.yaml
+kubectl apply -f manifests/gateway.yaml
+kubectl apply -f manifests/http-routes.yaml
+```
+
+Wait for the Gateway and routes:
+
+```bash
+kubectl wait gateway/vllm-xlb --for=condition=Programmed --timeout=10m
+kubectl wait httproute/vllm-gemma-4-e2b-route --for=jsonpath='{.status.parents[0].conditions[?(@.type=="Accepted")].status}=True --timeout=5m
+kubectl wait httproute/vllm-nemotron-nano-4b-route --for=jsonpath='{.status.parents[0].conditions[?(@.type=="Accepted")].status}=True --timeout=5m
+```
+
+## Test routing
+
+Get the external Gateway address:
+
+```bash
+export GW_IP=$(kubectl get gateway/vllm-xlb -o jsonpath='{.status.addresses[0].value}')
+export GW_PORT=80
+```
+
+Send a request to Gemma:
+
+```bash
+cat > gemma.json <<'EOF'
+{
+  "model": "google/gemma-4-E2B-it",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Explain in three concise bullets why GPU partitioning can help serve multiple small language models on one accelerator."
+    }
+  ],
+  "max_tokens": 256,
+  "temperature": 0.2,
+  "top_p": 0.95
+}
+EOF
+
+curl -sS http://${GW_IP}:${GW_PORT}/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @gemma.json | jq -r '.model, .choices[0].message.content'
+```
+
+Send a request to Nemotron:
+
+```bash
+cat > nemotron.json <<'EOF'
+{
+  "model": "nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Explain in three concise bullets why GPU partitioning can help serve multiple small language models on one accelerator."
+    }
+  ],
+  "max_tokens": 256,
+  "temperature": 0.2,
+  "top_p": 0.95
+}
+EOF
+
+curl -sS http://${GW_IP}:${GW_PORT}/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d @nemotron.json | jq -r '.model, .choices[0].message.content'
+```
+
+If the Gateway was created recently, wait a few minutes and retry if you receive a temporary `404`, `400`, or `503` while the load balancer finishes reconciling.
+
+## Observe metrics
+
+GKE managed workload monitoring collects vLLM and Inference Gateway metrics. Useful checks:
+
+```bash
+kubectl describe hpa vllm-gemma-4-e2b
+kubectl describe hpa vllm-nemotron-nano-4b
+```
+
+In Cloud Monitoring, dashboard templates are available for:
+
+- `vLLM Prometheus Overview`
+- `GKE Inference Gateway Prometheus Overview`
+
+## Clean up
+
+Delete the application resources:
+
+```bash
+helm uninstall vllm-gemma-4-e2b --ignore-not-found
+helm uninstall vllm-nemotron-nano-4b --ignore-not-found
+helm uninstall bbr --ignore-not-found
+
+kubectl delete -f manifests/http-routes.yaml --ignore-not-found
+kubectl delete -f manifests/gateway.yaml --ignore-not-found
+kubectl delete -f manifests/inference-objectives.yaml --ignore-not-found
+kubectl delete -f manifests/vllm-nemotron.yaml --ignore-not-found
+kubectl delete -f manifests/vllm-gemma.yaml --ignore-not-found
+kubectl delete secret hf-secret --ignore-not-found
+```
+
+Delete the cluster and proxy-only subnet:
+
+```bash
+gcloud container clusters delete ${CLUSTER_NAME} \
+  --region=${REGION} \
+  --quiet
+
+gcloud compute networks subnets delete ${REGION}-proxy-only-subnet \
+  --region=${REGION} \
+  --quiet
+```

--- a/inference/gke/vllm-inference-gateway/epp-values.yaml
+++ b/inference/gke/vllm-inference-gateway/epp-values.yaml
@@ -1,0 +1,35 @@
+provider:
+  gke:
+    autopilot: true
+inferenceExtension:
+  replicas: 3
+  monitoring:
+    prometheus:
+      enabled: true
+  pluginsConfigFile: plugins-v2-custom.yaml
+  pluginsCustomConfig:
+    plugins-v2-custom.yaml: |
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      plugins:
+      - type: queue-scorer
+      - type: kv-cache-utilization-scorer
+      - type: prefix-cache-scorer
+        parameters:
+          hashBlockSize: 32
+          maxPrefixBlocksToMatch: 64
+          lruCapacityPerServer: 10986
+      - type: max-score-picker
+        parameters:
+          maxNumOfEndpoints: 1
+      - type: single-profile-handler
+      schedulingProfiles:
+      - name: default
+        plugins:
+        - pluginRef: queue-scorer
+          weight: 1
+        - pluginRef: kv-cache-utilization-scorer
+          weight: 1
+        - pluginRef: prefix-cache-scorer
+          weight: 1
+        - pluginRef: max-score-picker

--- a/inference/gke/vllm-inference-gateway/manifests/gateway.yaml
+++ b/inference/gke/vllm-inference-gateway/manifests/gateway.yaml
@@ -1,0 +1,10 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: vllm-xlb
+spec:
+  gatewayClassName: gke-l7-regional-external-managed
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: http

--- a/inference/gke/vllm-inference-gateway/manifests/http-routes.yaml
+++ b/inference/gke/vllm-inference-gateway/manifests/http-routes.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vllm-gemma-4-e2b-route
+spec:
+  parentRefs:
+  - name: vllm-xlb
+  rules:
+  - matches:
+    - headers:
+      - type: Exact
+        name: X-Gateway-Model-Name
+        value: google/gemma-4-E2B-it
+      path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: vllm-gemma-4-e2b
+      group: inference.networking.k8s.io
+      kind: InferencePool
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vllm-nemotron-nano-4b-route
+spec:
+  parentRefs:
+  - name: vllm-xlb
+  rules:
+  - matches:
+    - headers:
+      - type: Exact
+        name: X-Gateway-Model-Name
+        value: nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
+      path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: vllm-nemotron-nano-4b
+      group: inference.networking.k8s.io
+      kind: InferencePool

--- a/inference/gke/vllm-inference-gateway/manifests/inference-objectives.yaml
+++ b/inference/gke/vllm-inference-gateway/manifests/inference-objectives.yaml
@@ -1,0 +1,19 @@
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: gemma-4-e2b-it
+spec:
+  priority: 10
+  poolRef:
+    group: inference.networking.k8s.io
+    name: vllm-gemma-4-e2b
+---
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceObjective
+metadata:
+  name: nemotron-nano-4b
+spec:
+  priority: 10
+  poolRef:
+    group: inference.networking.k8s.io
+    name: vllm-nemotron-nano-4b

--- a/inference/gke/vllm-inference-gateway/manifests/vllm-gemma.yaml
+++ b/inference/gke/vllm-inference-gateway/manifests/vllm-gemma.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-gemma-4-e2b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-gemma-4-e2b
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: vllm-gemma-4-e2b
+    spec:
+      serviceAccountName: default
+      containers:
+      - name: inference-server
+        image: vllm/vllm-openai:latest
+        args:
+        - --model=google/gemma-4-E2B-it
+        - --tensor-parallel-size=1
+        - --max-model-len=8192
+        - --gpu-memory-utilization=0.85
+        - '--limit-mm-per-prompt={"image":0,"audio":0}'
+        env:
+        - name: HUGGING_FACE_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: hf_api_token
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "4"
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+            nvidia.com/gpu: "1"
+          limits:
+            cpu: "4"
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+            nvidia.com/gpu: "1"
+        volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 30
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          failureThreshold: 1
+          timeoutSeconds: 1
+        startupProbe:
+          failureThreshold: 3600
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+        cloud.google.com/gke-gpu-partition-size: 2g.48gb
+        cloud.google.com/gke-accelerator-count: "1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-gemma-4-e2b
+spec:
+  selector:
+    app: vllm-gemma-4-e2b
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vllm-gemma-4-e2b
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: vllm-gemma-4-e2b
+  minReplicas: 1
+  maxReplicas: 1
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 60
+  metrics:
+  - type: External
+    external:
+      metric:
+        name: prometheus.googleapis.com|inference_pool_average_kv_cache_utilization|gauge
+        selector:
+          matchLabels:
+            metric.labels.name: vllm-gemma-4-e2b
+      target:
+        type: AverageValue
+        averageValue: 10m

--- a/inference/gke/vllm-inference-gateway/manifests/vllm-nemotron.yaml
+++ b/inference/gke/vllm-inference-gateway/manifests/vllm-nemotron.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-nemotron-nano-4b
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm-nemotron-nano-4b
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: vllm-nemotron-nano-4b
+    spec:
+      serviceAccountName: default
+      containers:
+      - name: inference-server
+        image: vllm/vllm-openai:latest
+        args:
+        - --model=nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
+        - --tensor-parallel-size=1
+        - --max-model-len=8192
+        - --gpu-memory-utilization=0.85
+        - --max-num-seqs=8
+        - --trust-remote-code
+        - --mamba_ssm_cache_dtype=float32
+        env:
+        - name: HUGGING_FACE_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hf-secret
+              key: hf_api_token
+        ports:
+        - containerPort: 8000
+          name: http
+          protocol: TCP
+        resources:
+          requests:
+            cpu: "4"
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+            nvidia.com/gpu: "1"
+          limits:
+            cpu: "4"
+            memory: 32Gi
+            ephemeral-storage: 10Gi
+            nvidia.com/gpu: "1"
+        volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+        lifecycle:
+          preStop:
+            sleep:
+              seconds: 30
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          periodSeconds: 1
+          successThreshold: 1
+          failureThreshold: 1
+          timeoutSeconds: 1
+        startupProbe:
+          failureThreshold: 3600
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+        cloud.google.com/gke-gpu-partition-size: 2g.48gb
+        cloud.google.com/gke-accelerator-count: "1"
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - vllm-gemma-4-e2b
+            topologyKey: kubernetes.io/hostname
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-nemotron-nano-4b
+spec:
+  selector:
+    app: vllm-nemotron-nano-4b
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: vllm-nemotron-nano-4b
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: vllm-nemotron-nano-4b
+  minReplicas: 1
+  maxReplicas: 1
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 60
+  metrics:
+  - type: External
+    external:
+      metric:
+        name: prometheus.googleapis.com|inference_pool_average_kv_cache_utilization|gauge
+        selector:
+          matchLabels:
+            metric.labels.name: vllm-nemotron-nano-4b
+      target:
+        type: AverageValue
+        averageValue: 10m


### PR DESCRIPTION
## Summary
- Add a GKE vLLM Inference Gateway recipe under `inference/gke/vllm-inference-gateway`.
- Include standalone setup instructions for GKE Autopilot, Inference Gateway CRDs, custom metrics adapter, Hugging Face token secret, Gateway routing, and cleanup.
- Add reusable manifests for Gemma and NVIDIA Nemotron vLLM deployments, services, HPAs, InferenceObjectives, Gateway, and HTTPRoutes.
- Update the inference index with the new sample.

## Validation
- Ran `/Users/juguerra/.codex/skills/labs-to-recipes/scripts/check_recipe_conversion.py nvidia-gcp-samples/inference/gke/vllm-inference-gateway`.
- Parsed all new YAML files with Ruby `YAML.load_stream`.
- Rendered the v1.3.1 InferencePool and body-based-routing Helm charts with the recipe values.
- Ran `git diff --check`.

## Not run
- Did not live deploy to GKE. Local `kubectl --dry-run=client` attempted to contact an existing GKE context, but the stored gcloud account token is invalid.