### PR TITLE
Fix Isaac Lab Newton setup instructions

### DIFF
--- a/physical-ai/compute-engine/isaac-lab-newton/README.md
+++ b/physical-ai/compute-engine/isaac-lab-newton/README.md
@@ -15,26 +15,19 @@ You will deploy the workstation, connect to a remote accelerated desktop with Th
 - G4 quota and capacity in the zone where you deploy the workstation. This sample was written for the NVIDIA RTX PRO 6000 GPU.
 - A local clone of this repository.
 
-Set your project and target zone:
+Set your project and target zone. Choose a zone where your project has G4 quota
+and NVIDIA RTX PRO 6000 GPU capacity:
 
 ```bash
 export PROJECT_ID=<YOUR_PROJECT_ID>
 export ZONE=<YOUR_ZONE>
 export DEPLOYMENT_NAME=isaacsim-workstation
-export VM_NAME=isaacsimworkstation-vm
+export VM_NAME="${DEPLOYMENT_NAME}-vm"
 
 gcloud config set project "${PROJECT_ID}"
 ```
 
-Enable the baseline Google Cloud APIs:
-
-```bash
-gcloud services enable \
-  compute.googleapis.com \
-  cloudresourcemanager.googleapis.com \
-  iam.googleapis.com \
-  serviceusage.googleapis.com
-```
+If you choose a different deployment name in Marketplace, update `DEPLOYMENT_NAME` before running the later commands.
 
 ## Task 1. Deploy the Isaac Sim Development Workstation
 
@@ -70,19 +63,22 @@ gcloud services enable \
 
    - **Deployment name**: `isaacsim-workstation`
    - **Service Account ID**: `isaacsim-workstation`
-   - **Zone**: the zone you exported as `ZONE`
+   - **Zone**: the zone you selected for `ZONE`
 
    ![Set deployment parameters](./img/set_parameters.png)
 
 9. Click **Deploy**. The deployment can take several minutes.
 
-If service account creation fails, retry the deployment in the same zone and select the service account that was created by the first attempt.
+If service account creation fails, retry the deployment in the same zone and
+select the service account that was created by the first attempt. You might also
+need to use a new deployment name; if you do, re-export `DEPLOYMENT_NAME` and
+`VM_NAME` with the new values before running later commands.
 
 ## Task 2. Connect to the VM and set the Ubuntu password
 
 1. In the Google Cloud console, open **Compute Engine** > **VM instances**.
 
-2. Click **SSH** for the `isaacsimworkstation-vm` instance.
+2. Click **SSH** for the VM instance named `${VM_NAME}`.
 
 3. In the SSH session, set a password for the `ubuntu` user. You will use this account for the ThinLinc desktop login.
 
@@ -104,7 +100,7 @@ Upload the ThinLinc installer script and Newton tutorial archive to the workstat
 gcloud compute scp \
   scripts/thinlinc.sh \
   scripts/newton-gcn.tar.gz \
-  ubuntu@"${VM_NAME}":~/ \
+  "${VM_NAME}":~/ \
   --zone="${ZONE}" \
   --project="${PROJECT_ID}"
 ```
@@ -117,9 +113,11 @@ In the SSH session connected to the workstation, run:
 cd ~
 chmod +x thinlinc.sh
 bash ./thinlinc.sh
+sudo install -o ubuntu -g ubuntu -m 0644 newton-gcn.tar.gz /home/ubuntu/newton-gcn.tar.gz
+ls -lh /home/ubuntu/newton-gcn.tar.gz
 ```
 
-Create a firewall rule for ThinLinc web access. For production or shared environments, restrict `SOURCE_RANGE` to your client IP address instead of `0.0.0.0/0`.
+From your local terminal or Cloud Shell, create a firewall rule for ThinLinc web access. For production or shared environments, restrict `SOURCE_RANGE` to your client IP address instead of `0.0.0.0/0`.
 
 ```bash
 export SOURCE_RANGE=0.0.0.0/0
@@ -175,8 +173,8 @@ When copying commands from your browser into the remote desktop, use the ThinLin
 Extract the tutorial workspace:
 
 ```bash
-cd ~
-tar -xf newton-gcn.tar.gz
+cd /home/ubuntu
+tar -xzf /home/ubuntu/newton-gcn.tar.gz
 cd newton-gcn-gcn_instructions
 ```
 
@@ -195,6 +193,23 @@ ls -lh task2/lab/task/franka_cube/source/franka_cube/franka_cube/tasks/direct/fr
 Expected size is approximately 1.3 MB.
 
 ## Task 6. Run simulations
+
+By default, these scripts open the native Isaac Sim viewport in the ThinLinc
+desktop. If the viewport opens but stays black, rerun the script with the Viser
+browser visualizer:
+
+```bash
+sudo bash run_local.sh task2/lab/task/franka_cube/scripts/run_baseline.py \
+  --headless \
+  --visualizer viser \
+  --num_envs 1 \
+  --num_steps 1000 \
+  --step_delay 0.02
+```
+
+The script prints the Viser URL. Open that URL from a browser inside the
+ThinLinc desktop. The `--step_delay` flag slows the simulation so the motion is
+easier to inspect; omit it for faster runs.
 
 Run the baseline simulation:
 
@@ -255,6 +270,17 @@ Run the pre-trained cube grasping policy:
 
 ```bash
 sudo bash run_local.sh task2/lab/task/franka_cube/scripts/run_policy.py
+```
+
+For paced browser visualization of the trained policy, run:
+
+```bash
+sudo bash run_local.sh task2/lab/task/franka_cube/scripts/run_policy.py \
+  --headless \
+  --visualizer viser \
+  --num_envs 1 \
+  --num_steps 1000 \
+  --step_delay 0.02
 ```
 
 ## Cleanup

--- a/physical-ai/compute-engine/isaac-lab-newton/scripts/newton-gcn.tar.gz
+++ b/physical-ai/compute-engine/isaac-lab-newton/scripts/newton-gcn.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ad810ba0dfbeca6eb978b2db334bd634c56c490700c91790fcabc4aa35df8b6
-size 1213357
+oid sha256:77600421a387927b95036c8324e1882dbafd7c8f3eb2ccd0ad8041e720c5ad8c
+size 1212891


### PR DESCRIPTION
## Summary\n- clarify zone and deployment retry guidance for the Isaac Lab Newton sample\n- remove the unnecessary manual API enablement step\n- make the Newton tutorial archive handoff and extraction use /home/ubuntu explicitly\n- repack the tutorial archive without macOS extended metadata so Ubuntu tar extraction is clean\n- clarify the Viser fallback for black Isaac Sim viewports over ThinLinc\n\n## Validation\n- python3 /Users/juguerra/.codex/skills/labs-to-recipes/scripts/check_recipe_conversion.py physical-ai/compute-engine/isaac-lab-newton\n- tar -tzf physical-ai/compute-engine/isaac-lab-newton/scripts/newton-gcn.tar.gz